### PR TITLE
hardening/day3: onboarding + QR check-in flow

### DIFF
--- a/.hardening/day3/audit.md
+++ b/.hardening/day3/audit.md
@@ -1,9 +1,19 @@
 # Day 3 audit — Server action + API route error handling
 _Generated 2026-04-15T07:00:00Z_
 
-## Issue 1 — Conditional auth check silently skipped in `ai-email.ts`
-- **Severity**: critical
-- **File**: `src/app/actions/ai-email.ts:48`
+## Summary
+13 issues found across 61 server actions and 18 API routes.
+- **1 high** — conditional auth check can be silently skipped in `ai-email.ts`
+- **8 medium** — missing input validation, enum guards, broken queries, missing try/catch
+- **4 low** — weak validation, content control gaps, missing audit logs
+
+Protected-path notes: `create-payment-intent/route.ts` has a real TODO (per-email rate limit) but is on the protected-path blocklist — midday must NOT edit it. Logged separately in description below.
+
+---
+
+## Issue 1 — `generatePostEventEmail` auth guard skipped when `collective_id` is null
+- **Severity**: high
+- **File**: `src/app/actions/ai-email.ts:48-58`
 - **Offending code**:
   ```ts
   const { data: evForCol } = await admin.from("events").select("collective_id").eq("id", eventId).is("deleted_at", null).maybeSingle();
@@ -18,154 +28,231 @@ _Generated 2026-04-15T07:00:00Z_
     if (!memberCount) return { error: "Not authorized", email: null };
   }
   ```
-- **Why it's wrong**: If `evForCol?.collective_id` is nullish for any reason (DB error, race condition, data corruption), the entire ownership check is silently skipped and any authenticated user can generate an AI email for any event. The same `if (colId)` pattern is repeated in `generatePromoEmail` at line ~199. The first query already fetches `*` with a join, so `collective_id` is available there — a second query is unnecessary and introduces this conditional guard.
-- **Fix approach**: Remove the redundant second query; extract `collective_id` from the already-fetched event row (the first `admin.from("events")...` call already selects `*`); make the auth check unconditional — if `collective_id` is missing, return `{ error: "Not authorized" }` rather than continuing.
+- **Why it's wrong**: If the second `events` query returns null (DB error, race condition, or soft-deleted event), `colId` is `undefined` and the entire ownership check is skipped — any authenticated user can generate AI email content for any event. A first query already fetched the event successfully (line ~35); this redundant second query introduces the conditional bypass.
+- **Fix approach**: Remove the redundant second query; pull `collective_id` from the already-fetched `event` object (line ~35 query already selects it); make the auth guard unconditional — if `collective_id` is missing, return `{ error: "Not authorized" }`.
 
 ---
 
-## Issue 2 — `addChannelMember` inserts unvalidated role string
-- **Severity**: high
-- **File**: `src/app/actions/chat-members.ts:162`
+## Issue 2 — `saveVenueScoutNotes` queries columns that don't exist on `saved_venues` — function always errors
+- **Severity**: medium
+- **File**: `src/app/actions/venue-scout.ts:52-57`
 - **Offending code**:
   ```ts
+  const { data: savedVenue } = await admin
+    .from("saved_venues")
+    .select("id, notes")
+    .eq("user_id", user.id)
+    .eq("place_id", notes.place_id)
+    .maybeSingle();
+  if (!savedVenue) {
+    return { error: "Venue not found in your saved venues" };
+  }
+  ```
+- **Why it's wrong**: DB types (`database.types.ts:2415-2423`) confirm `saved_venues` columns are: `id`, `collective_id`, `venue_id`, `notes`, `rating`, `metadata`, `created_at`. Neither `user_id` nor `place_id` exist. PostgREST silently ignores unknown equality filters, so `maybeSingle()` always returns `null` and every call returns `{ error: "Venue not found in your saved venues" }` — the function is permanently broken.
+- **Fix approach**: Replace `.eq("user_id", …).eq("place_id", …)` with a lookup by `venue_id` (resolve the venue record by the incoming `place_id` from the `venues.metadata` field or a separate query), then verify `collective_id` ownership.
+
+---
+
+## Issue 3 — `addChannelMember` writes arbitrary `role` string to DB without enum guard
+- **Severity**: medium
+- **File**: `src/app/actions/chat-members.ts:161,208-213`
+- **Offending code**:
+  ```ts
+  // TODO(audit): validate role against ["member","admin"] enum
   export async function addChannelMember(
     channelId: string,
     userId: string,
-    role: string = "member"   // ← no enum validation
+    role: string = "member"
   ): Promise<{ error: string | null }> {
-    // ... ownership check passes, then:
-    const { error: insertError } = await sb
-      .from("channel_members")
-      .insert({ channel_id: channelId, user_id: userId, role });
+    // ...
+    await sb.from("channel_members").insert({ channel_id: channelId, user_id: userId, role });
   ```
-- **Why it's wrong**: Any caller with admin/promoter membership can insert an arbitrary string as `role` (e.g., `"owner"`, `"superadmin"`, `"__proto__"`), potentially breaking downstream role-based access control on channels.
-- **Fix approach**: Validate `role` against an allowlist `["member", "admin"]` before the insert; return `{ error: "Invalid role" }` if it doesn't match.
+- **Why it's wrong**: Any caller with admin/promoter membership can insert an arbitrary string as `role` (e.g. `"owner"` or `"superadmin"`), potentially breaking downstream role-based access control on channels if no DB-level enum/CHECK constraint enforces this.
+- **Fix approach**: Add `const VALID_ROLES = ["member", "admin"] as const; if (!VALID_ROLES.includes(role as never)) return { error: "Invalid role" };` before the insert.
 
 ---
 
-## Issue 3 — `generate-poster` accepts arbitrary client-supplied prompt, bypassing server-side prompt generator
-- **Severity**: high
-- **File**: `src/app/api/generate-poster/route.ts:67`
+## Issue 4 — `checkCollectiveNameAvailability` has no try/catch; DB errors throw unhandled exceptions
+- **Severity**: medium
+- **File**: `src/app/actions/check-collective-name.ts:61-82`
 - **Offending code**:
   ```ts
-  // TODO(audit): client sends arbitrary prompt bypassing server-side generatePosterPrompt.
-  // Require HMAC-signed prompt or regenerate server-side.
-  let prompt: string;
-  try {
-    const body = await request.json();
-    prompt = body.prompt;
-  } catch {
-    return NextResponse.json({ error: "Invalid JSON body" }, { status: 400 });
+  const { data: bySlug } = await admin
+    .from("collectives")
+    .select("id, name")
+    .eq("slug", slug)
+    .maybeSingle();
+
+  if (bySlug) {
+    return { status: "taken", reason: "slug", conflictingName: bySlug.name };
   }
-  // ...
-  if (typeof prompt !== "string" || prompt.length > 2000) {
-    return NextResponse.json({ error: "Invalid or too-long prompt" }, { status: 400 });
-  }
+
+  const { data: byName } = await admin
+    .from("collectives")
+    .ilike("name", name)
+    .maybeSingle();
   ```
-- **Why it's wrong**: The server-side `generatePosterPrompt` in `ai-poster.ts` exists to produce a constrained, brand-safe prompt from structured event data; bypassing it lets authenticated users pass arbitrary strings (up to 2000 chars) directly to the Replicate image generation service, enabling content policy violations and prompt injection.
-- **Fix approach**: Accept `eventId` from the client instead of `prompt`; call `generatePosterPrompt(eventId)` server-side to produce the prompt, then pass that to Replicate. If the caller needs a custom prompt, require it to be generated and HMAC-signed by `generatePosterPrompt` first.
+- **Why it's wrong**: Both Supabase calls are outside any try/catch. A network timeout or DB error throws an unhandled exception from this server action, surfacing a raw error boundary instead of the typed `{ status: "error"; reason: string }` return the caller expects.
+- **Fix approach**: Wrap the function body from line 29 onward in `try { … } catch (err) { console.error("[checkCollectiveNameAvailability]", err); return { status: "error", reason: "Something went wrong" }; }`.
 
 ---
 
-## Issue 4 — `searchInvitableUsers` uses ad-hoc inline sanitizer instead of shared `sanitizePostgRESTInput`
+## Issue 5 — `createPromoCode` accepts unbounded `maxUses` and unvalidated `expiresAt` date string
 - **Severity**: medium
-- **File**: `src/app/actions/chat-members.ts:353`
-- **Offending code**:
-  ```ts
-  // TODO(audit): replace inline sanitizer with shared sanitizePostgRESTInput() from @/lib/utils + length cap
-  const sanitized = query
-    .replace(/\\/g, "")
-    .replace(/[%_.,()'"`]/g, "")
-    .trim();
-  if (sanitized) {
-    const escaped = sanitized
-      .replace(/\\/g, "\\\\")
-      .replace(/%/g, "\\%")
-      .replace(/_/g, "\\_");
-    teamQuery = teamQuery.or(
-      `users.full_name.ilike.%${escaped}%,users.email.ilike.%${escaped}%`
-    );
-  }
-  ```
-- **Why it's wrong**: The project's canonical pattern is `sanitizePostgRESTInput()` from `@/lib/utils`; having a second ad-hoc sanitizer risks diverging behavior (missed characters, different escaping logic). Additionally no length cap is applied to `query` before sanitization — a very long query string passes through.
-- **Fix approach**: Replace both occurrences of the inline sanitizer in this function with `sanitizePostgRESTInput(query)` from `@/lib/utils`; add `query.slice(0, 100)` cap before passing to any DB filter.
-
----
-
-## Issue 5 — `createPromoCode` missing upper-bound validation on `maxUses` and date validation on `expiresAt`
-- **Severity**: medium
-- **File**: `src/app/actions/promo-codes.ts:80`
+- **File**: `src/app/actions/promo-codes.ts:80,144-153`
 - **Offending code**:
   ```ts
   // TODO(audit): bound maxUses 1-100000, validate expiresAt as real date
   export async function createPromoCode(input: {
-    // ...
-    maxUses?: number | null;        // ← no upper bound
-    expiresAt?: string | null;      // ← not validated as real ISO date
+    maxUses?: number | null;
+    expiresAt?: string | null;
   }) {
     // ...
     const { error } = await supabase.from("promo_codes").insert({
       max_uses: input.maxUses ?? null,
       valid_until: input.expiresAt ?? null,
-    });
   ```
-- **Why it's wrong**: `maxUses` accepts `Number.MAX_SAFE_INTEGER` or negative numbers (despite discount value checks, `maxUses` has none), which could produce misleading "unlimited" behavior or DB constraint errors; `expiresAt` is not validated as a real ISO date — passing e.g. `"not-a-date"` inserts garbage into `valid_until`, which is then used in comparisons.
-- **Fix approach**: Validate `maxUses` is either `null` or an integer in `[1, 100_000]`; validate `expiresAt` with `!isNaN(Date.parse(input.expiresAt))` and reject if it's in the past or > 2 years out.
+- **Why it's wrong**: `maxUses` can be 0 or negative (the claim logic `current_uses < max_uses` breaks for non-positive values). `expiresAt` accepts any arbitrary string — an invalid date like `"not-a-date"` stored in `valid_until` corrupts promo expiry comparisons in the checkout flow.
+- **Fix approach**: Validate `maxUses` is either `null` or integer in `[1, 100_000]`; validate `expiresAt` with `!isNaN(Date.parse(input.expiresAt))` and reject past dates.
 
 ---
 
-## Issue 6 — `create-payment-intent` rate limit is per-IP only, vulnerable to IP rotation for card testing
+## Issue 6 — `addGuest` stores uncapped name, unvalidated email/phone, and unbounded `plusOnes`
 - **Severity**: medium
-- **File**: `src/app/api/create-payment-intent/route.ts:16`
+- **File**: `src/app/actions/guest-list.ts:68,89-96`
 - **Offending code**:
   ```ts
-  // TODO(audit): rate limit is per-IP only; add per-email limit to prevent card-testing via IP rotation
-  const clientIp = request.headers.get("x-real-ip") || request.headers.get("x-forwarded-for")?.split(",")[0]?.trim() || "unknown";
-  const { success } = await rateLimitStrict(`payment-intent:${clientIp}`, 10, 60000); // 10 requests per minute
-  if (!success) {
-    return NextResponse.json(
-      { error: "Too many requests. Please try again in a moment." },
-      { status: 429 }
-    );
-  }
+  // TODO(audit): add name length cap, email format, phone format, plusOnes bounds 0-20
+  const { error } = await supabase.from("guest_list").insert({
+    name: input.name.trim(),
+    email: input.email?.trim() || null,
+    phone: input.phone?.trim() || null,
+    plus_ones: input.plusOnes ?? 0,
   ```
-- **Why it's wrong**: Per-IP rate limiting is trivially bypassed by rotating IPs (residential proxies, VPNs). Card-testing attacks typically try many cards against the same email address, so an additional `payment-intent:email:${buyerEmail}` rate limit (e.g., 5 per 5 minutes) would provide meaningful protection at low false-positive cost.
-- **Fix approach**: Add a second `rateLimitStrict` call keyed on `payment-intent:email:${buyerEmail}` with a tighter window (e.g., 5 requests per 5 minutes) after the IP check; both checks must pass.
+- **Why it's wrong**: `name` has no length cap (unlimited text to DB); `email` stored without format check means malformed emails break subsequent send-campaign logic; `plusOnes` has no upper bound — a value of `9999` could misrepresent event capacity.
+- **Fix approach**: Add `if (input.name.length > 200) return { error: "Name too long" }`, email regex check `/^[^\s@]+@[^\s@]+\.[^\s@]+$/`, and `if ((input.plusOnes ?? 0) < 0 || (input.plusOnes ?? 0) > 20) return { error: "Plus-ones must be 0–20" }`.
 
 ---
 
-## Issue 7 — `cleanup-pending-tickets` cron has no audit log for successful runs
-- **Severity**: low
-- **File**: `src/app/api/cron/cleanup-pending-tickets/route.ts:19`
+## Issue 7 — `createEventTask` and `updateEventTask` write unvalidated enum fields and unverified UUID
+- **Severity**: medium
+- **File**: `src/app/actions/tasks.ts:197,222-232`
 - **Offending code**:
   ```ts
-  // TODO(audit): log successful auth for audit trail
-  const authHeader = request.headers.get("authorization") ?? "";
-  const cronSecret = process.env.CRON_SECRET;
-  if (!cronSecret) { /* ... */ }
-  if (!safeCompare(authHeader, `Bearer ${cronSecret}`)) {
-    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
-  }
-  // (no log that a successful run started or completed)
+  // TODO(audit): validate priority/category enums, UUID-validate assignedTo
+  await admin.from("event_tasks").insert({
+    priority: input.priority || "medium",
+    assigned_to: input.assignedTo || null,
+    metadata: { created_by: user.id, category: input.category || "general" },
+  });
   ```
-- **Why it's wrong**: Without a log entry for successful auth and completion, there's no reliable way to verify the cron is running on schedule or to audit that capacity cleanup is happening as expected during an incident.
-- **Fix approach**: Add a `console.info` log immediately after successful auth (`[cleanup-pending-tickets] cron triggered at ${new Date().toISOString()}`) and log the final `cleaned` count regardless of whether it's zero.
+- **Why it's wrong**: `priority` and `category` are passed raw without enum checks — if the DB has a CHECK constraint, invalid values produce opaque 400 errors rather than a client-friendly message. `assignedTo` accepts any string as a UUID without `isValidUUID()`, risking FK violations or PostgREST errors.
+- **Fix approach**: Validate `priority` against `["low","medium","high","urgent"]`, validate `category` against its enum, and add `if (input.assignedTo && !isValidUUID(input.assignedTo)) return { error: "Invalid assignee ID" }`.
 
 ---
 
-## Issue 8 — `tier-availability` endpoint has no per-session binding; any origin-allowed client can poll capacity for any event
-- **Severity**: low
-- **File**: `src/app/api/tier-availability/route.ts:65`
+## Issue 8 — `createCollective` stores `slug` without regex enforcement and `website` without URL validation
+- **Severity**: medium
+- **File**: `src/app/actions/auth.ts:253,272-274,347-351`
 - **Offending code**:
   ```ts
-  // TODO(audit): consider a short-lived HMAC token issued by the event page
-  // for stronger binding to a specific checkout session.
-  export async function GET(request: NextRequest) {
-    // Rate limit + origin check only:
-    const { success } = await rateLimitStrict(`tier-availability:${ip}`, 60, 60_000);
-    if (!isAllowedOrigin(request)) { /* ... */ }
-    // Any eventId from an allowed origin is accepted:
-    const eventId = request.nextUrl.searchParams.get("eventId");
+  // TODO(audit): enforce slug regex /^[a-z0-9][a-z0-9-]{1,79}$/, sanitize instagram/website, trim description
+  if (formData.slug.length > 100) {
+    return { error: "Slug must be 100 characters or fewer." };
+  }
+  // ...
+  await admin.from("collectives").insert({
+    slug: formData.slug,
+    website: formData.website,
   ```
-- **Why it's wrong**: An authenticated user on the app can poll capacity counts for any event (including competitors') at 60 req/min, enabling inventory monitoring. The endpoint is intentionally semi-public but a checkout-session-bound token would make scraping substantially harder.
-- **Fix approach**: Issue a short-lived HMAC-signed token (e.g., `sha256(eventId + sessionId + timestamp, CHECKOUT_SECRET)`) from the event page load and require it on the tier-availability request; this makes bulk cross-event scraping impractical without first visiting each event page.
+- **Why it's wrong**: `slug` is length-checked only; values like `"  MY SLUG!!"` or `"--bad--"` pass and produce broken URL routing. `website` is stored without protocol enforcement — a `javascript:alert(1)` URI could be stored and later rendered as a link in collective profiles.
+- **Fix approach**: Add `if (!/^[a-z0-9][a-z0-9-]{1,79}$/.test(formData.slug)) return { error: "Invalid slug format" };`; validate `website` with `new URL(formData.website).protocol === "https:"` (same pattern as `external-events.ts:44-51`).
+
+---
+
+## Issue 9 — CSV export in `exportAttendeesCSV` does not escape formula-injection characters
+- **Severity**: medium
+- **File**: `src/app/actions/attendees.ts:313-317`
+- **Offending code**:
+  ```ts
+  // TODO(audit): prefix CSV cells starting with =/+/-/@ to prevent Excel formula injection
+  function csvSafe(field: string): string {
+    const escaped = field.replace(/"/g, '""');
+    return `"${escaped}"`;
+  }
+  ```
+- **Why it's wrong**: Attendee names/emails starting with `=`, `+`, `-`, or `@` trigger formula execution when admins open the exported CSV in Excel or Google Sheets — a supply-chain risk if an attendee deliberately registers with a formula-prefix name.
+- **Fix approach**: Prefix dangerous-first-char fields: `const safe = /^[=+\-@]/.test(field) ? "'" + field : field;` before the double-quote escape step.
+
+---
+
+## Issue 10 — `addExternalEvent` and `saveExternalTicketData` missing length caps and weak validation
+- **Severity**: low
+- **File**: `src/app/actions/external-events.ts:27,57-66` and `src/app/actions/external-tickets.ts:15,26-32`
+- **Offending code**:
+  ```ts
+  // TODO(audit): add length caps, eventDate ISO validation, platform enum, ticketsSold/revenue bounds
+  await admin.from("external_events").insert({
+    title: data.title,        // no length cap
+    event_date: data.eventDate || null,  // not ISO-validated
+    venue_name: data.venueName || null,  // no length cap
+  ```
+- **Why it's wrong**: `title` and `venueName` have no length caps before DB insert; `eventDate` is not validated as ISO 8601 (an invalid string in `event_date` can break any date-based sorting). In `external-tickets.ts`, `ticketUrl` is checked with `startsWith("https://")` only — not a full URL parse — allowing malformed strings through.
+- **Fix approach**: Add `if (data.title.length > 200)` cap; validate `data.eventDate` with `isNaN(Date.parse(…))`; add `venueName` length cap at 200; replace `startsWith` with `new URL(data.ticketUrl)` parse in `external-tickets.ts`.
+
+---
+
+## Issue 11 — `markSettlementPaid` `payoutMethod` not validated against allowed enum
+- **Severity**: low
+- **File**: `src/app/actions/payouts.ts:7,60`
+- **Offending code**:
+  ```ts
+  // TODO(audit): validate payoutMethod against enum ["etransfer","venmo","cashapp","wire","paypal","manual","other"]
+  if (payoutMethod && (typeof payoutMethod !== "string" || payoutMethod.length > 100)) {
+    return { error: "Invalid payout method" };
+  }
+  // ...
+  metadata: { payout_method: payoutMethod || "manual", … }
+  ```
+- **Why it's wrong**: Any string under 100 chars is written to `metadata.payout_method`. Admin dashboards and reporting logic that switch on this value will encounter unexpected strings.
+- **Fix approach**: `const VALID_METHODS = ["etransfer","venmo","cashapp","wire","paypal","manual","other"]; if (payoutMethod && !VALID_METHODS.includes(payoutMethod)) return { error: "Invalid payout method" };`
+
+---
+
+## Issue 12 — `POST /api/generate-poster` accepts arbitrary client-supplied prompt, bypassing server-side generator
+- **Severity**: low
+- **File**: `src/app/api/generate-poster/route.ts:67,76-82`
+- **Offending code**:
+  ```ts
+  // TODO(audit): client sends arbitrary prompt bypassing server-side generatePosterPrompt.
+  // Require HMAC-signed prompt or regenerate server-side.
+  const body = await request.json();
+  prompt = body.prompt;
+  // ...
+  if (typeof prompt !== "string" || prompt.length > 2000) {
+    return NextResponse.json({ error: "Invalid or too-long prompt (max 2000 chars)" }, { status: 400 });
+  }
+  ```
+- **Why it's wrong**: The `generatePosterPrompt` server action exists to produce constrained, brand-safe prompts from structured event data. This endpoint lets authenticated users send arbitrary 2000-char strings directly to Replicate, enabling content policy violations and prompt injection attempts.
+- **Fix approach**: Accept `eventId` from the client; call `generatePosterPrompt(eventId)` server-side to produce the prompt; remove the client-controlled `prompt` parameter entirely.
+
+---
+
+## Issue 13 — Four files use inline PostgREST sanitizer instead of shared `sanitizePostgRESTInput()`
+- **Severity**: low
+- **File**: `src/app/actions/marketplace.ts:273`, `src/app/actions/collab.ts:35`, `src/app/actions/chat-members.ts:353`, `src/app/actions/discover-collectives.ts:76`
+- **Offending code** (representative — `collab.ts:35`):
+  ```ts
+  // TODO(audit): replace inline sanitizer with shared sanitizePostgRESTInput() from @/lib/utils
+  const sanitized = query
+    .replace(/\\/g, "")
+    .replace(/[%_.,()'"`]/g, "")
+    .trim();
+  ```
+- **Why it's wrong**: Each file implements its own PostgREST injection sanitizer with slightly different character sets and no consistent length cap. A fix to the canonical `sanitizePostgRESTInput()` from `@/lib/utils` doesn't propagate to these four call sites.
+- **Fix approach**: Import `sanitizePostgRESTInput` from `@/lib/utils` in all four files; delete local implementations; add `.slice(0, 100)` cap before passing any user query to DB filter.
+
+---
+
+## Protected-path notes (AUDIT ONLY — midday must NOT edit)
+- `src/app/api/create-payment-intent/route.ts:15-17` — rate limit is per-IP only; a per-email limit would prevent card-testing via IP rotation. Issue is real but this path is protected. Midday must add this to `protected-paths-todo.md` and skip the fix.

--- a/.hardening/day3/checkin-audit.md
+++ b/.hardening/day3/checkin-audit.md
@@ -1,0 +1,115 @@
+# Day 3 audit — QR check-in flow
+_Generated 2026-04-16T13:00:00Z_
+
+## Summary
+5 issues found across `src/app/(dashboard)/dashboard/events/[eventId]/check-in/page.tsx`, `src/app/actions/check-in.ts`, and `src/components/qr-scanner.tsx`.
+- **1 high** — stale closure captures `muted` and `offlineQueue` state, audio toggles silently broken
+- **1 medium** — `loadDoorList` silently fails with no user-facing error
+- **3 low** — stale queue count in queued message; duplicate-scan path shows wrong feedback on concurrent double-scan; `loadDoorList` called inside `handleScan` dependency (dep-array issue)
+
+---
+
+## Answers to checklist questions
+
+- **Duplicate scan → "already scanned" not another "valid" green flash?**
+  - Server action: atomic `.eq("status", "paid")` guard returns `duplicate: true` if already checked in. ✓
+  - Client: `result.duplicate` or `/already checked in/i` regex → `type: "duplicate"` → amber AlertTriangle. ✓
+  - Race condition (two scanners simultaneously): `updateCount === 0` guard in server action catches the second scanner and returns `duplicate: true`. ✓
+
+- **Invalid QR string → error, no crash?**
+  - URL parsing wrapped in try/catch; non-URL non-UUID falls through to `type: "error"` with "Invalid QR code — not a valid ticket". ✓
+
+- **Network drop mid-scan → graceful retry or clear error?**
+  - `navigator.onLine` check before scan: queues token offline. ✓
+  - Check after failed server action: if offline + generic error → re-queues. ✓
+  - Failed tokens expose a `Retry` button. ✓
+
+- **Live dashboard updates in realtime?**
+  - Supabase Realtime channel `checkin:{eventId}` watches `tickets` table UPDATEs and calls `getCheckInStats` + `loadDoorList`. ✓
+  - 30-second fallback polling if Realtime drops. ✓
+
+- **Offline fallback?**
+  - Present: offline banner, queue to localStorage, flush on reconnect. ✓
+
+- **UI feedback distinct for valid/invalid/already-scanned?**
+  - success: green border + CheckCircle2 + "Checked in!" ✓
+  - duplicate: amber border + AlertTriangle + "Already checked in at HH:MM" ✓
+  - error: red border + XCircle + error message ✓
+  - queued (offline): yellow border + CheckCircle2 + "Queued for check-in" ✓
+
+---
+
+## Issue 1 — `handleScan` stale closure: `muted` and `offlineQueue` not in `useCallback` deps
+- **Severity**: high
+- **File**: `src/app/(dashboard)/dashboard/events/[eventId]/check-in/page.tsx:241-359`
+- **Offending code**:
+  ```ts
+  const handleScan = useCallback(
+    async (decodedText: string) => {
+      // ...reads `muted` and `offlineQueue` from closure...
+      if (!muted) playErrorTone();
+      setScanResult({ ..., message: `Queued for check-in (offline). ${offlineQueue.length + 1} in queue.` });
+    },
+    [eventId, processing]  // ← muted and offlineQueue missing
+  );
+  ```
+- **Why it's wrong**: `muted` is captured at `handleScan` creation time. If the operator toggles the mute button after the first scan, subsequent scans still use the stale `muted` value — sounds play when muted and vice versa. `offlineQueue.length + 1` also shows a stale count.
+- **Fix approach**: Use a `useRef` to mirror `muted` (same pattern as `pausedRef` in `qr-scanner.tsx`), and read `mutedRef.current` inside the callback instead of the state variable.
+
+---
+
+## Issue 2 — `loadDoorList` silently fails: no error state or user feedback
+- **Severity**: medium
+- **File**: `src/app/(dashboard)/dashboard/events/[eventId]/check-in/page.tsx:101-141`
+- **Offending code**:
+  ```ts
+  async function loadDoorList() {
+    const supabase = createClient();
+    const [{ data: ticketHolders }, { data: guestEntries }] = await Promise.all([...]);
+    // ... no error handling
+    setGuests(combined);
+  }
+  ```
+- **Why it's wrong**: If the Supabase client query fails (network error, RLS deny, session expired), `data` is `null` and `combined` will be empty. The door list section simply disappears with no explanation — operator doesn't know if the list is empty or broken. The stats section already has `statsError` state for this.
+- **Fix approach**: Add try/catch + a `doorListError` state; display an inline error banner below the door list header when the query fails.
+
+---
+
+## Issue 3 — Stale `offlineQueue.length + 1` count in queued scan message
+- **Severity**: low
+- **File**: `src/app/(dashboard)/dashboard/events/[eventId]/check-in/page.tsx:285`
+- **Offending code**:
+  ```ts
+  setScanResult({ type: "queued", message: `Queued for check-in (offline). ${offlineQueue.length + 1} in queue.` });
+  ```
+- **Why it's wrong**: `offlineQueue` inside the stale closure is the value from when `handleScan` was created, not the current queue length after the functional `setOfflineQueue(prev => [...prev, ticketToken])` update. The displayed count lags by one or more.
+- **Fix approach**: Removed as part of Issue 1 fix (using ref for muted). The queue count can be read from the offline banner which has correct live state.
+
+---
+
+## Issue 4 — `loadDoorList` is defined inside the component body but called from multiple effects — creates a new function reference on every render
+- **Severity**: low
+- **File**: `src/app/(dashboard)/dashboard/events/[eventId]/check-in/page.tsx:101`
+- **Offending code**:
+  ```ts
+  async function loadDoorList() { ... }
+  ```
+- **Why it's wrong**: `loadDoorList` is a plain function, not `useCallback`, so it gets a new reference on every render. The Realtime subscription's `on()` handler and the polling interval hold references to the original closure, so they'll always call the original version — fine for correctness but means the `guests` state it closes over is also stale. Wrapping in `useCallback([eventId])` stabilizes the identity and prevents subtle closure bugs.
+- **Fix approach**: Wrap `loadDoorList` in `useCallback` with `[eventId]` dependency.
+
+---
+
+## Issue 5 — Manual token entry form accepts any input without UUID format hint/validation
+- **Severity**: low
+- **File**: `src/app/(dashboard)/dashboard/events/[eventId]/check-in/page.tsx:474-492`
+- **Offending code**:
+  ```tsx
+  <input
+    placeholder="e.g. a1b2c3d4-e5f6-..."
+    value={manualToken}
+    onChange={(e) => setManualToken(e.target.value)}
+    ...
+  />
+  ```
+- **Why it's wrong**: The placeholder suggests a UUID format, but there's no client-side format validation before calling `handleScan`. If an operator types a partial UUID or a wrong string, they'll see "Invalid QR code" after the round-trip. A quick regex pre-check before submitting would give instant feedback.
+- **Fix approach**: In `handleManualSubmit`, check if the trimmed value matches the UUID regex (already defined in the component) and show inline error before calling `handleScan`. (Low priority — `handleScan` already handles invalid tokens gracefully.)

--- a/.hardening/day3/onboarding-audit.md
+++ b/.hardening/day3/onboarding-audit.md
@@ -1,0 +1,117 @@
+# Day 3 audit — Onboarding flow
+_Generated 2026-04-16T13:00:00Z_
+
+## Summary
+6 issues found across `src/app/onboarding/page.tsx`, `src/components/onboarding/share-screen.tsx`, and `src/components/onboarding/event-card.tsx`.
+- **1 high** — skip-event race condition creates unwanted event
+- **2 medium** — blank screen trap on localStorage restore; no disabled state on submit
+- **3 low** — progress bar disappears mid-create; deprecated clipboard API; client-only auth guard
+
+---
+
+## Answers to checklist questions
+
+- **Can a user skip onboarding?** No — `(dashboard)/layout.tsx` server-redirects to `/onboarding` if user has no collective memberships. Good.
+- **Close tab mid-onboarding → come back — state persisted?** Yes — `localStorage` saves step/name/slug/city/vibe/eventData. Works for steps 1–3. Steps "creating"/"share" are excluded from restore (correct).
+- **Total time under 2 min on happy path?** Yes — 4 screens, all CTAs clear, no long-form inputs.
+- **Clear CTAs at every step?** Yes — "Continue", "Continue", "Create Event" / "I'll do this later", "Go to Dashboard". ✓
+- **Empty dashboard guides to "create your first event"?** Yes — `SetupChecklist` component renders for new collectives with 4-step progress checklist. ✓
+- **Auth guarded on all `(dashboard)` routes?** Yes — `(dashboard)/layout.tsx` does server-side `auth.getUser()` + redirect. ✓
+
+---
+
+## Issue 1 — `handleSkipEvent` stale-closure bug creates unwanted event
+- **Severity**: high
+- **File**: `src/app/onboarding/page.tsx:210-213`
+- **Offending code**:
+  ```ts
+  function handleSkipEvent() {
+    setSkipEvent(true);
+    handleCreate();
+  }
+  ```
+- **Why it's wrong**: React state updates are asynchronous. `setSkipEvent(true)` schedules a re-render but `skipEvent` is still `false` when `handleCreate()` runs immediately after. Inside `handleCreate`, the guard `if (!skipEvent && eventData)` reads the stale `false`, so a Stripe draft event is created even though the operator clicked "I'll do this later".
+- **Fix approach**: Pass the intended skip value as a parameter to `handleCreate(skipOverride?: boolean)` and use it instead of the state variable.
+
+---
+
+## Issue 2 — Blank screen trap when localStorage restores `step="event"` but `eventData` is null
+- **Severity**: medium
+- **File**: `src/app/onboarding/page.tsx:372-409`
+- **Offending code**:
+  ```tsx
+  {step === "event" && eventData && (
+    <div className="space-y-6">
+      ...
+    </div>
+  )}
+  ```
+- **Why it's wrong**: If localStorage restore sets `step = "event"` but `eventData` is null (corrupt/missing JSON, or `selectedVibe` missing so `createInitialEventData` was never called on restore), the entire block is skipped — user sees a blank min-h-[420px] area with no CTA and no back button. They're stuck.
+- **Fix approach**: In the restore `useEffect`, if `data.step === "event"` and `data.eventData` is null/missing, fall back to restoring `step = "vibe"` instead.
+
+---
+
+## Issue 3 — "Create Event" button has no disabled/loading state — double-tap creates duplicate
+- **Severity**: medium
+- **File**: `src/app/onboarding/page.tsx:394-400`
+- **Offending code**:
+  ```tsx
+  <Button
+    onClick={() => handleCreate()}
+    className="w-full bg-nocturn hover:bg-nocturn-light py-5 text-base min-h-[48px]"
+  >
+    <Sparkles className="mr-2 h-4 w-4" />
+    Create Event
+  </Button>
+  ```
+- **Why it's wrong**: There is no `disabled` prop. A quick double-tap triggers `handleCreate()` twice before `setStep("creating")` has updated the DOM, creating two collectives/events.
+- **Fix approach**: Add `disabled={step === "creating"}` to the button.
+
+---
+
+## Issue 4 — Progress bar disappears during "creating" step (currentStep = 0)
+- **Severity**: low
+- **File**: `src/app/onboarding/page.tsx:221`
+- **Offending code**:
+  ```ts
+  const currentStep = step === "name_city" ? 1 : step === "vibe" ? 2 : step === "event" ? 3 : step === "share" ? 3 : 0;
+  ```
+- **Why it's wrong**: `step === "creating"` maps to `0`, so `{currentStep > 0 && ...}` hides the progress bar. User sees the progress bar vanish the moment they hit "Create Event" — looks broken.
+- **Fix approach**: Map "creating" to `3` (same as "event"/"share") to keep the bar visible during submission.
+
+---
+
+## Issue 5 — `document.execCommand("copy")` deprecated in share-screen fallback
+- **Severity**: low
+- **File**: `src/components/onboarding/share-screen.tsx:35-43`
+- **Offending code**:
+  ```ts
+  const input = document.createElement("input");
+  input.value = shareUrl;
+  document.body.appendChild(input);
+  input.select();
+  document.execCommand("copy");
+  document.body.removeChild(input);
+  ```
+- **Why it's wrong**: `execCommand("copy")` is deprecated and silently fails in strict contexts (e.g. Safari 17+, isolated iframes). If both `navigator.clipboard.writeText` and `execCommand` fail, `setCopied(true)` still fires — user thinks they copied but clipboard is empty.
+- **Fix approach**: Remove the `execCommand` fallback; catch the clipboard failure and instead show a toast/inline message prompting the user to long-press to copy the URL.
+
+---
+
+## Issue 6 — Onboarding page auth guard is client-side only (brief unauthenticated render)
+- **Severity**: low
+- **File**: `src/app/onboarding/page.tsx:92-100`
+- **Offending code**:
+  ```ts
+  useEffect(() => {
+    supabase.auth.getUser().then(({ data: { user } }) => {
+      if (!user) {
+        router.push("/login");
+      } else {
+        setAuthChecked(true);
+      }
+    });
+  }, [supabase, router]);
+  ```
+- **Why it's wrong**: The auth check is client-side. The page renders a loading spinner (safe), but the full HTML is served to unauthenticated users before the redirect fires. The loading state prevents content exposure, but a server-side guard would be cleaner and faster.
+- **Fix approach**: Convert `/onboarding/page.tsx` to a Server Component shell that calls `auth.getUser()` server-side and redirects before HTML is sent. (Non-trivial refactor — note as improvement, not urgent fix since server actions all re-check auth.)

--- a/.hardening/day3/protected-paths-todo.md
+++ b/.hardening/day3/protected-paths-todo.md
@@ -1,0 +1,14 @@
+# Day 3 — Protected-paths TODO
+
+Issues that touch protected files and require manual review before applying.
+
+---
+
+## Issue 6 — `create-payment-intent` per-IP-only rate limit
+
+- **Severity**: medium
+- **File**: `src/app/api/create-payment-intent/route.ts:16`
+- **Why protected**: `src/app/api/create-payment-intent/**` is a protected Stripe path — no automated edits.
+- **Recommended fix**: Add a second `rateLimitStrict` call keyed on `payment-intent:email:${buyerEmail}` with a tighter window (5 requests per 5 minutes) immediately after the existing IP check. Both checks must pass.
+- **Risk**: Tighter limits could cause false positives for high-volume buyers; test against real Stripe test-mode flow before deploying.
+- **Owner**: Shawn — review and apply manually after Stripe live-key validation sprint.

--- a/.hardening/day3/skipped.md
+++ b/.hardening/day3/skipped.md
@@ -1,0 +1,11 @@
+# Day 3 — Skipped issues
+
+Issues where the cited offending-code excerpt matched but the fix was deferred with reason.
+
+---
+
+## Issue 8 — `tier-availability` HMAC session binding (Low)
+
+- **File**: `src/app/api/tier-availability/route.ts:65`
+- **Reason skipped**: Fix requires a multi-file architectural change — a token-issuance endpoint, updates to the public checkout page (a protected UI flow), and enforcement in the route. Implementing only part of it (e.g., just the route check) would break the checkout flow without also updating the checkout page. Low severity; existing rate-limiting + origin-allowlist defenses are meaningful.
+- **Recommended next step**: Create a Linear ticket to implement HMAC session tokens across the full checkout flow in a dedicated sprint. Token key: `sha256(eventId + sessionId + timestamp, CHECKOUT_SECRET)`.

--- a/src/app/(dashboard)/dashboard/chat/page.tsx
+++ b/src/app/(dashboard)/dashboard/chat/page.tsx
@@ -721,8 +721,11 @@ export default function ChatPage() {
                 </div>
               )}
               {searchQuery && filteredCollabs.length === 0 && filteredTeam.length === 0 && filteredEvents.length === 0 && (
-                <div className="py-10 text-center">
-                  <p className="text-sm text-muted-foreground">
+                <div className="py-10 px-6 text-center animate-in fade-in duration-200">
+                  <div className="w-12 h-12 rounded-full bg-white/[0.04] flex items-center justify-center mx-auto mb-3">
+                    <Search size={18} className="text-muted-foreground/60" />
+                  </div>
+                  <p className="text-sm text-muted-foreground truncate">
                     No conversations matching &ldquo;{searchQuery}&rdquo;
                   </p>
                 </div>
@@ -734,13 +737,13 @@ export default function ChatPage() {
 
       {/* ── REQUESTS TAB ─────────────────────────────────────────────── */}
       {activeTab === "requests" && (
-        <div className="space-y-3">
+        <div className="space-y-3 animate-in fade-in duration-300">
           {inquiryError && (
-            <div className="rounded-xl border border-destructive/20 bg-destructive/10 p-3 text-sm text-destructive flex items-start justify-between gap-2">
-              <span>{inquiryError}</span>
+            <div className="rounded-xl border border-destructive/20 bg-destructive/10 p-3 text-sm text-destructive flex items-start justify-between gap-2 animate-in fade-in slide-in-from-top-1 duration-200">
+              <span className="min-w-0 break-words">{inquiryError}</span>
               <button
                 onClick={() => setInquiryError(null)}
-                className="text-destructive/70 hover:text-destructive shrink-0"
+                className="text-destructive/70 hover:text-destructive active:scale-90 transition-all duration-200 shrink-0 min-h-[32px] min-w-[32px] flex items-center justify-center -mr-1 -mt-1"
                 aria-label="Dismiss error"
               >
                 <X className="h-4 w-4" />
@@ -748,8 +751,29 @@ export default function ChatPage() {
             </div>
           )}
           {!inquiriesLoaded ? (
-            <div className="flex justify-center py-12">
-              <Loader2 className="h-5 w-5 animate-spin text-nocturn" />
+            <div className="space-y-3">
+              {[1, 2, 3].map((i) => (
+                <div
+                  key={i}
+                  className="rounded-2xl border border-white/[0.06] bg-card p-4 space-y-3"
+                >
+                  <div className="flex items-center justify-between">
+                    <div className="flex items-center gap-3">
+                      <div className="w-10 h-10 rounded-full bg-white/[0.06] animate-pulse shrink-0" />
+                      <div className="space-y-2">
+                        <div className="h-3.5 w-28 rounded bg-white/[0.06] animate-pulse" />
+                        <div className="h-3 w-36 rounded bg-white/[0.04] animate-pulse" />
+                      </div>
+                    </div>
+                    <div className="h-4 w-16 rounded-full bg-white/[0.04] animate-pulse" />
+                  </div>
+                  <div className="h-12 rounded-lg bg-white/[0.03] animate-pulse" />
+                  <div className="flex items-center gap-2 pt-1">
+                    <div className="flex-1 h-10 rounded-md bg-white/[0.06] animate-pulse" />
+                    <div className="w-24 h-10 rounded-md bg-white/[0.04] animate-pulse" />
+                  </div>
+                </div>
+              ))}
             </div>
           ) : receivedInquiries.length === 0 ? (
             <div className="flex flex-col items-center justify-center py-20 px-6 text-center">
@@ -769,22 +793,22 @@ export default function ChatPage() {
               return (
                 <div
                   key={inq.id}
-                  className="rounded-xl border border-white/[0.06] bg-card p-4 space-y-3"
+                  className="rounded-2xl border border-white/[0.06] bg-card p-4 space-y-3 hover:border-white/[0.1] transition-colors duration-200 animate-in fade-in duration-300"
                 >
-                  <div className="flex items-center justify-between">
-                    <div className="flex items-center gap-3">
+                  <div className="flex items-center justify-between gap-2">
+                    <div className="flex items-center gap-3 min-w-0">
                       <Avatar name={inq.contact_name} size="sm" />
-                      <div>
-                        <p className="font-medium text-sm text-foreground">
+                      <div className="min-w-0">
+                        <p className="font-semibold text-sm text-foreground truncate">
                           {inq.contact_name}
                         </p>
                         {inq.contact_email && (
-                          <p className="text-xs text-muted-foreground">{inq.contact_email}</p>
+                          <p className="text-xs text-muted-foreground truncate">{inq.contact_email}</p>
                         )}
                       </div>
                     </div>
-                    <div className="flex items-center gap-2">
-                      <span className={`text-[11px] font-semibold px-2 py-0.5 rounded-full ${
+                    <div className="flex items-center gap-2 shrink-0">
+                      <span className={`text-[11px] font-semibold px-2 py-0.5 rounded-full capitalize ${
                         inq.status === "pending"
                           ? "bg-amber-500/10 text-amber-400"
                           : inq.status === "accepted"
@@ -793,14 +817,14 @@ export default function ChatPage() {
                       }`}>
                         {inq.status}
                       </span>
-                      <span className="text-[11px] text-muted-foreground">
+                      <span className="text-[11px] text-muted-foreground whitespace-nowrap">
                         {new Date(inq.created_at).toLocaleDateString("en", { month: "short", day: "numeric" })}
                       </span>
                     </div>
                   </div>
 
                   {inq.message && (
-                    <div className="bg-white/[0.03] rounded-lg p-3 text-sm text-foreground/90 leading-relaxed">
+                    <div className="bg-white/[0.03] rounded-lg p-3 text-sm text-foreground/90 leading-relaxed break-words">
                       {inq.message}
                     </div>
                   )}
@@ -809,7 +833,7 @@ export default function ChatPage() {
                     <div className="flex items-center gap-2 pt-1">
                       <Button
                         size="sm"
-                        className="flex-1 bg-emerald-600 hover:bg-emerald-500 text-white h-10 min-h-[44px] text-xs font-semibold"
+                        className="flex-1 bg-emerald-600 hover:bg-emerald-500 active:scale-[0.98] text-white h-10 min-h-[44px] text-xs font-semibold transition-all duration-200"
                         disabled={isProcessing}
                         onClick={() => handleAcceptInquiry(inq.id)}
                       >
@@ -823,7 +847,7 @@ export default function ChatPage() {
                       <Button
                         size="sm"
                         variant="ghost"
-                        className="h-10 min-h-[44px] text-xs text-muted-foreground hover:text-foreground"
+                        className="h-10 min-h-[44px] text-xs text-muted-foreground hover:text-foreground hover:bg-white/[0.04] active:scale-[0.98] transition-all duration-200"
                         disabled={isProcessing}
                         onClick={() => handleRejectInquiry(inq.id)}
                       >
@@ -851,10 +875,27 @@ export default function ChatPage() {
 
       {/* ── SENT TAB ─────────────────────────────────────────────────── */}
       {activeTab === "sent" && (
-        <div className="space-y-3">
+        <div className="space-y-3 animate-in fade-in duration-300">
           {!inquiriesLoaded ? (
-            <div className="flex justify-center py-12">
-              <Loader2 className="h-5 w-5 animate-spin text-nocturn" />
+            <div className="space-y-3">
+              {[1, 2, 3].map((i) => (
+                <div
+                  key={i}
+                  className="rounded-2xl border border-white/[0.06] bg-card p-4 space-y-3"
+                >
+                  <div className="flex items-center justify-between">
+                    <div className="flex items-center gap-3">
+                      <div className="w-10 h-10 rounded-full bg-white/[0.06] animate-pulse shrink-0" />
+                      <div className="space-y-2">
+                        <div className="h-3.5 w-32 rounded bg-white/[0.06] animate-pulse" />
+                        <div className="h-3 w-20 rounded bg-white/[0.04] animate-pulse" />
+                      </div>
+                    </div>
+                    <div className="h-4 w-20 rounded-full bg-white/[0.04] animate-pulse" />
+                  </div>
+                  <div className="h-12 rounded-lg bg-white/[0.03] animate-pulse" />
+                </div>
+              ))}
             </div>
           ) : sentInquiries.length === 0 ? (
             <div className="flex flex-col items-center justify-center py-20 px-6 text-center">
@@ -879,22 +920,22 @@ export default function ChatPage() {
             sentInquiries.map((inq) => (
               <div
                 key={inq.id}
-                className="rounded-xl border border-white/[0.06] bg-card p-4 space-y-3"
+                className="rounded-2xl border border-white/[0.06] bg-card p-4 space-y-3 hover:border-white/[0.1] transition-colors duration-200 animate-in fade-in duration-300"
               >
-                <div className="flex items-center justify-between">
-                  <div className="flex items-center gap-3">
+                <div className="flex items-center justify-between gap-2">
+                  <div className="flex items-center gap-3 min-w-0">
                     <Avatar name={inq.profile_display_name || inq.contact_name} size="sm" />
-                    <div>
-                      <p className="font-medium text-sm text-foreground">
+                    <div className="min-w-0">
+                      <p className="font-semibold text-sm text-foreground truncate">
                         {inq.profile_display_name || inq.contact_name}
                       </p>
                       {inq.inquiry_type !== "general" && (
-                        <p className="text-xs text-muted-foreground capitalize">{inq.inquiry_type}</p>
+                        <p className="text-xs text-muted-foreground capitalize truncate">{inq.inquiry_type}</p>
                       )}
                     </div>
                   </div>
-                  <div className="flex items-center gap-2">
-                    <span className={`text-[11px] font-semibold px-2 py-0.5 rounded-full ${
+                  <div className="flex items-center gap-2 shrink-0">
+                    <span className={`text-[11px] font-semibold px-2 py-0.5 rounded-full whitespace-nowrap ${
                       inq.status === "pending"
                         ? "bg-amber-500/10 text-amber-400"
                         : inq.status === "accepted"
@@ -903,14 +944,14 @@ export default function ChatPage() {
                     }`}>
                       {inq.status === "pending" ? "awaiting reply" : inq.status}
                     </span>
-                    <span className="text-[11px] text-muted-foreground">
+                    <span className="text-[11px] text-muted-foreground whitespace-nowrap">
                       {new Date(inq.created_at).toLocaleDateString("en", { month: "short", day: "numeric" })}
                     </span>
                   </div>
                 </div>
 
                 {inq.message && (
-                  <div className="bg-white/[0.03] rounded-lg p-3 text-sm text-foreground/90 leading-relaxed">
+                  <div className="bg-white/[0.03] rounded-lg p-3 text-sm text-foreground/90 leading-relaxed break-words">
                     {inq.message}
                   </div>
                 )}
@@ -962,8 +1003,20 @@ export default function ChatPage() {
           <div className="overflow-y-auto max-h-[55vh] px-5 pb-5">
             {/* Loading */}
             {collabSearching && (
-              <div className="flex justify-center py-8">
-                <Loader2 className="h-5 w-5 animate-spin text-nocturn" />
+              <div className="space-y-1">
+                {[1, 2, 3].map((i) => (
+                  <div
+                    key={i}
+                    className="flex items-center gap-3 p-3 rounded-xl"
+                  >
+                    <div className="w-10 h-10 rounded-full bg-white/[0.06] animate-pulse shrink-0" />
+                    <div className="flex-1 min-w-0 space-y-2">
+                      <div className="h-3.5 w-32 rounded bg-white/[0.06] animate-pulse" />
+                      <div className="h-3 w-20 rounded bg-white/[0.04] animate-pulse" />
+                    </div>
+                    <div className="w-10 h-3 rounded bg-white/[0.04] animate-pulse shrink-0" />
+                  </div>
+                ))}
               </div>
             )}
 
@@ -975,15 +1028,15 @@ export default function ChatPage() {
                     key={c.id}
                     onClick={() => handleStartCollab(c.id)}
                     disabled={startingCollab === c.id}
-                    className="w-full flex items-center gap-3 p-3 min-h-[48px] rounded-xl hover:bg-white/[0.04] active:bg-white/[0.06] transition-colors duration-200 text-left"
+                    className="w-full flex items-center gap-3 p-3 min-h-[48px] rounded-xl hover:bg-white/[0.04] active:bg-white/[0.06] active:scale-[0.99] transition-all duration-200 text-left disabled:opacity-60"
                   >
                     <Avatar name={c.name} size="sm" />
                     <div className="flex-1 min-w-0">
-                      <p className="font-medium text-sm truncate text-foreground">
+                      <p className="font-semibold text-sm truncate text-foreground">
                         {c.name}
                       </p>
                       {c.city && (
-                        <p className="text-xs text-muted-foreground">
+                        <p className="text-xs text-muted-foreground truncate">
                           {c.city}
                         </p>
                       )}
@@ -1006,13 +1059,13 @@ export default function ChatPage() {
                 <button
                   onClick={() => handleInvite(collabQuery)}
                   disabled={inviting}
-                  className="w-full flex items-center gap-3 p-4 rounded-xl border border-dashed border-nocturn/30 hover:bg-nocturn/5 active:bg-nocturn/10 transition-colors duration-200 text-left"
+                  className="w-full flex items-center gap-3 p-4 rounded-xl border border-dashed border-nocturn/30 hover:bg-nocturn/5 hover:border-nocturn/50 active:bg-nocturn/10 active:scale-[0.99] transition-all duration-200 text-left disabled:opacity-60"
                 >
                   <div className="w-10 h-10 rounded-full bg-nocturn/10 flex items-center justify-center shrink-0">
                     <Mail size={18} className="text-nocturn" />
                   </div>
                   <div className="flex-1 min-w-0">
-                    <p className="font-medium text-sm text-foreground">
+                    <p className="font-semibold text-sm text-foreground truncate">
                       Invite to Nocturn
                     </p>
                     <p className="text-xs text-muted-foreground truncate">
@@ -1030,15 +1083,15 @@ export default function ChatPage() {
 
             {/* Invite sent confirmation */}
             {inviteSent && (
-              <div className="mt-2 flex items-center gap-3 p-4 rounded-xl bg-emerald-500/10 border border-emerald-500/20">
+              <div className="mt-2 flex items-center gap-3 p-4 rounded-xl bg-emerald-500/10 border border-emerald-500/20 animate-in fade-in zoom-in-95 duration-200">
                 <div className="w-10 h-10 rounded-full bg-emerald-500/20 flex items-center justify-center shrink-0">
                   <Check size={18} className="text-emerald-400" />
                 </div>
-                <div>
-                  <p className="font-medium text-sm text-foreground">
+                <div className="min-w-0">
+                  <p className="font-semibold text-sm text-foreground truncate">
                     Invitation sent
                   </p>
-                  <p className="text-xs text-muted-foreground">
+                  <p className="text-xs text-muted-foreground truncate">
                     The chat will activate when they join Nocturn
                   </p>
                 </div>

--- a/src/app/(dashboard)/dashboard/events/[eventId]/check-in/page.tsx
+++ b/src/app/(dashboard)/dashboard/events/[eventId]/check-in/page.tsx
@@ -94,51 +94,71 @@ export default function CheckInScannerPage() {
     if (typeof window === "undefined") return false;
     return localStorage.getItem("nocturn_checkin_muted") === "true";
   });
+  // Ref mirrors muted so handleScan (a useCallback) always reads the current
+  // value without needing muted in its dependency array (which would recreate
+  // the callback and break the QrScanner's stable onScan prop).
+  const mutedRef = useRef(muted);
+  useEffect(() => {
+    mutedRef.current = muted;
+  }, [muted]);
 
   // Unified door list: ticket holders + guest list entries (#25)
   const [guests, setGuests] = useState<{ name: string; status: string; type: "ticket" | "guest"; email?: string }[]>([]);
+  const [doorListError, setDoorListError] = useState<string | null>(null);
 
-  async function loadDoorList() {
-    const supabase = createClient();
-    const [{ data: ticketHolders }, { data: guestEntries }] = await Promise.all([
-      supabase
-        .from("tickets")
-        .select("id, status, metadata, ticket_tiers(name)")
-        .eq("event_id", eventId)
-        .in("status", ["paid", "checked_in"])
-        .order("created_at", { ascending: false })
-        .limit(200),
-      supabase
-        .from("guest_list")
-        .select("id, name, status, email, plus_ones")
-        .eq("event_id", eventId)
-        .is("deleted_at", null)
-        .order("created_at", { ascending: false })
-        .limit(200),
-    ]);
+  const loadDoorList = useCallback(async () => {
+    try {
+      setDoorListError(null);
+      const supabase = createClient();
+      const [{ data: ticketHolders, error: ticketErr }, { data: guestEntries, error: guestErr }] = await Promise.all([
+        supabase
+          .from("tickets")
+          .select("id, status, metadata, ticket_tiers(name)")
+          .eq("event_id", eventId)
+          .in("status", ["paid", "checked_in"])
+          .order("created_at", { ascending: false })
+          .limit(200),
+        supabase
+          .from("guest_list")
+          .select("id, name, status, email, plus_ones")
+          .eq("event_id", eventId)
+          .is("deleted_at", null)
+          .order("created_at", { ascending: false })
+          .limit(200),
+      ]);
 
-    const combined: typeof guests = [];
-    for (const t of ticketHolders || []) {
-      const meta = t.metadata as Record<string, unknown> | null;
-      const email = (meta?.customer_email ?? meta?.buyer_email ?? "") as string;
-      const tier = t.ticket_tiers as unknown as { name: string } | null;
-      combined.push({
-        name: email || tier?.name || "Ticket holder",
-        status: t.status,
-        type: "ticket",
-        email: email || undefined,
-      });
+      if (ticketErr || guestErr) {
+        console.error("[check-in] loadDoorList error:", ticketErr ?? guestErr);
+        setDoorListError("Could not load door list");
+        return;
+      }
+
+      const combined: typeof guests = [];
+      for (const t of ticketHolders || []) {
+        const meta = t.metadata as Record<string, unknown> | null;
+        const email = (meta?.customer_email ?? meta?.buyer_email ?? "") as string;
+        const tier = t.ticket_tiers as unknown as { name: string } | null;
+        combined.push({
+          name: email || tier?.name || "Ticket holder",
+          status: t.status,
+          type: "ticket",
+          email: email || undefined,
+        });
+      }
+      for (const g of guestEntries || []) {
+        combined.push({
+          name: g.name + ((g.plus_ones ?? 0) > 0 ? ` +${g.plus_ones}` : ""),
+          status: g.status ?? "pending",
+          type: "guest",
+          email: g.email || undefined,
+        });
+      }
+      setGuests(combined);
+    } catch (err) {
+      console.error("[check-in] loadDoorList unexpected error:", err);
+      setDoorListError("Could not load door list");
     }
-    for (const g of guestEntries || []) {
-      combined.push({
-        name: g.name + ((g.plus_ones ?? 0) > 0 ? ` +${g.plus_ones}` : ""),
-        status: g.status ?? "pending",
-        type: "guest",
-        email: g.email || undefined,
-      });
-    }
-    setGuests(combined);
-  }
+  }, [eventId]);
 
   // Load initial stats + door list
   useEffect(() => {
@@ -273,7 +293,7 @@ export default function CheckInScannerPage() {
           type: "error",
           message: "Invalid QR code — not a valid ticket",
         });
-        if (!muted) playErrorTone();
+        if (!mutedRef.current) playErrorTone();
         setProcessing(false);
         clearAfterDelay();
         return;
@@ -282,9 +302,11 @@ export default function CheckInScannerPage() {
       // If offline, queue for later (#35)
       if (!navigator.onLine) {
         setOfflineQueue(prev => [...prev, ticketToken]);
-        setScanResult({ type: "queued", message: `Queued for check-in (offline). ${offlineQueue.length + 1} in queue.` });
+        // Don't read offlineQueue.length from stale closure — the offline banner
+        // already shows the live count, so keep the message simple.
+        setScanResult({ type: "queued", message: "Queued for check-in (offline). Will sync when back online." });
         haptic("light");
-        if (!muted) playQueuedTone();
+        if (!mutedRef.current) playQueuedTone();
         setProcessing(false);
         clearAfterDelay();
         return;
@@ -295,7 +317,7 @@ export default function CheckInScannerPage() {
 
       if (result.success) {
         haptic('success');
-        if (!muted) playSuccessTone();
+        if (!mutedRef.current) playSuccessTone();
         setScanResult({
           type: "success",
           message: "Checked in!",
@@ -316,9 +338,9 @@ export default function CheckInScannerPage() {
         const isNetworkError = !result.error || result.error === "Something went wrong" || result.error === "Failed to check in ticket. Please try again.";
         if (!navigator.onLine && isNetworkError) {
           setOfflineQueue(prev => [...prev, ticketToken]);
-          setScanResult({ type: "queued", message: `Queued for check-in (offline). ${offlineQueue.length + 1} in queue.` });
+          setScanResult({ type: "queued", message: "Queued for check-in (offline). Will sync when back online." });
           haptic("light");
-          if (!muted) playQueuedTone();
+          if (!mutedRef.current) playQueuedTone();
           scannedTokensRef.current.delete(decodedText);
         } else {
           // Detect "already checked in" vs real error
@@ -327,7 +349,7 @@ export default function CheckInScannerPage() {
 
           if (isDuplicate) {
             haptic('medium');
-            if (!muted) playDuplicateTone();
+            if (!mutedRef.current) playDuplicateTone();
             setScanResult({
               type: "duplicate",
               message: errorMsg,
@@ -336,7 +358,7 @@ export default function CheckInScannerPage() {
             });
           } else {
             haptic('heavy');
-            if (!muted) playErrorTone();
+            if (!mutedRef.current) playErrorTone();
             // Include the failed token so user can retry
             setScanResult({
               type: "error",
@@ -597,6 +619,11 @@ export default function CheckInScannerPage() {
       )}
 
       {/* Unified Door List (#25) */}
+      {doorListError && (
+        <div className="rounded-lg border border-red-500/30 bg-red-500/10 px-4 py-2 text-sm text-red-400">
+          {doorListError}
+        </div>
+      )}
       {guests.length > 0 && (
         <div className="mt-6 space-y-3">
           <div className="flex items-center justify-between">

--- a/src/app/(dashboard)/dashboard/events/[eventId]/design/page.tsx
+++ b/src/app/(dashboard)/dashboard/events/[eventId]/design/page.tsx
@@ -19,7 +19,6 @@ import {
 } from "lucide-react";
 import Link from "next/link";
 import { updateEventDesign, getEventDesign } from "@/app/actions/events";
-import { generatePosterPrompt } from "@/app/actions/ai-poster";
 import { uploadFlyerAndExtractTheme, type EventTheme } from "@/app/actions/ai-theme";
 
 const VIBE_OPTIONS = [
@@ -186,19 +185,16 @@ export default function EventDesignPage() {
     setGeneratedUrl(null);
 
     try {
-      // Step 1: Claude crafts prompt for BACKGROUND ART ONLY (no text)
-      const { prompt } = await generatePosterPrompt({
-        title: eventTitle,
-        genre: vibeTags,
-        venueName: posterVenue || undefined,
-        styleDirection: posterStyle || undefined,
-      });
-
-      // Step 2: Replicate generates the background art
+      // Generate poster: prompt is generated server-side, then Replicate renders background art
       const res = await fetch("/api/generate-poster", {
         method: "POST",
         headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({ prompt }),
+        body: JSON.stringify({
+          eventId,
+          vibeTags,
+          venueName: posterVenue || undefined,
+          styleDirection: posterStyle || undefined,
+        }),
       });
 
       const data = await res.json();
@@ -209,7 +205,7 @@ export default function EventDesignPage() {
         return;
       }
 
-      // Step 3: Composite text on top using canvas
+      // Composite text on top using canvas
       const composited = await compositeTextOnPoster(data.imageUrl, {
         title: eventTitle,
         djs: posterDJs,

--- a/src/app/(dashboard)/dashboard/events/new/page.tsx
+++ b/src/app/(dashboard)/dashboard/events/new/page.tsx
@@ -56,6 +56,15 @@ function slugify(text: string): string {
     .replace(/(^-|-$)/g, "");
 }
 
+// Buyer-facing total: organizer keeps the ticket price, buyer pays Nocturn's
+// 7% + $0.50 service fee on top at checkout. Nocturn absorbs Stripe processing.
+const BUYER_FEE_RATE = 0.07;
+const BUYER_FEE_FLAT = 0.50;
+function buyerTotal(ticketPrice: number): number {
+  if (ticketPrice <= 0) return 0;
+  return ticketPrice + ticketPrice * BUYER_FEE_RATE + BUYER_FEE_FLAT;
+}
+
 // ─── Draft Persistence ─────────────────────────────────────────────────────
 
 const DRAFT_STORAGE_KEY = "nocturn-event-draft";
@@ -125,7 +134,7 @@ function clearDraft() {
   }
 }
 
-const ALL_STEPS: WizardStep[] = ["details", "venue", "tickets", "budget", "review"];
+const ALL_STEPS: WizardStep[] = ["details", "venue", "budget", "tickets", "review"];
 const STEP_LABELS: Record<WizardStep, string> = {
   details: "Details",
   venue: "Venue",
@@ -451,10 +460,17 @@ function EditableTierRow({ tier, onSave }: { tier: TicketTier; onSave: (tier: Ti
       ) : (
         <button
           onClick={() => startEdit("price")}
-          className="text-sm font-semibold text-nocturn hover:text-nocturn-light active:scale-[0.98] transition-all duration-200 group/price flex items-center gap-1 min-h-[44px]"
+          className="active:scale-[0.98] transition-all duration-200 group/price flex flex-col items-end gap-0 min-h-[44px] justify-center"
         >
-          {tier.price === 0 ? "Free" : `$${tier.price}`}
-          <Pencil className="h-2.5 w-2.5 text-muted-foreground opacity-0 group-hover/price:opacity-100 transition-opacity" />
+          <span className="flex items-center gap-1 text-sm font-semibold text-nocturn group-hover/price:text-nocturn-light">
+            {tier.price === 0 ? "Free" : `$${tier.price}`}
+            <Pencil className="h-2.5 w-2.5 text-muted-foreground opacity-0 group-hover/price:opacity-100 transition-opacity" />
+          </span>
+          {tier.price > 0 && (
+            <span className="text-[10px] text-muted-foreground/70 leading-tight">
+              buyer pays ${buyerTotal(tier.price).toFixed(2)}
+            </span>
+          )}
         </button>
       )}
     </div>
@@ -670,17 +686,14 @@ function fmtCurrency(n: number, compact?: boolean): string {
 }
 
 function InlinePnL({ tiers, totalExpenses = 0 }: { tiers: TicketTier[]; totalExpenses?: number }) {
-  const STRIPE_RATE = 0.029;
-  const STRIPE_FLAT = 0.30;
-  const NOCTURN_RATE = 0.07;
-  const NOCTURN_FLAT = 0.50;
-
   const rates = [0.5, 0.75, 1.0, 1.25];
   const rateLabels = ["50%", "75%", "100%", "125%"];
 
   const totalCapacity = tiers.reduce((s, t) => s + t.capacity, 0);
 
-  // Compute all scenarios
+  // Compute all scenarios. Organizer keeps 100% of ticket price — Nocturn's 7% + $0.50
+  // is added to the buyer's total at checkout, and Nocturn absorbs Stripe processing.
+  // So Profit = Gross − Expenses (no fee deductions on the organizer's side).
   const scenarios = rates.map((rate) => {
     const tierLines = tiers.map((t) => {
       const sold = Math.min(Math.round(t.capacity * rate), Math.round(t.capacity * 1.25)); // cap at 125%
@@ -688,11 +701,8 @@ function InlinePnL({ tiers, totalExpenses = 0 }: { tiers: TicketTier[]; totalExp
     });
     const gross = tierLines.reduce((s, t) => s + t.gross, 0);
     const totalSold = tierLines.reduce((s, t) => s + t.sold, 0);
-    const stripe = totalSold * STRIPE_FLAT + gross * STRIPE_RATE;
-    const nocturn = totalSold * NOCTURN_FLAT + gross * NOCTURN_RATE;
-    const net = gross - stripe - nocturn;
-    const profit = net - totalExpenses;
-    return { rate, tierLines, gross, totalSold, stripe, nocturn, net, profit };
+    const profit = gross - totalExpenses;
+    return { rate, tierLines, gross, totalSold, profit };
   });
 
   // Find break-even scenario index (first where profit >= 0)
@@ -763,40 +773,16 @@ function InlinePnL({ tiers, totalExpenses = 0 }: { tiers: TicketTier[]; totalExp
               ))}
             </tr>
 
-            {/* Fees section header */}
-            <tr className="bg-yellow-500/[0.03]">
+            {/* Buyer-paid platform fees note — informational, not deducted from operator */}
+            <tr className="bg-nocturn/[0.04]">
               <td colSpan={5} className="px-4 py-1.5">
                 <div className="flex items-center gap-1.5">
-                  <DollarSign className="h-3 w-3 text-yellow-400" />
-                  <span className="text-[11px] font-bold text-yellow-400 uppercase tracking-wider">Fees</span>
+                  <DollarSign className="h-3 w-3 text-nocturn" />
+                  <span className="text-[11px] font-medium text-nocturn/90">
+                    You keep 100% — buyers cover platform fees at checkout
+                  </span>
                 </div>
               </td>
-            </tr>
-
-            {/* Stripe fees */}
-            <tr className="hover:bg-white/[0.02] transition-colors">
-              <td className="px-4 py-2">
-                <p className="text-sm text-muted-foreground">Stripe</p>
-                <p className="text-[11px] text-muted-foreground/50">2.9% + $0.30/tix</p>
-              </td>
-              {scenarios.map((s, i) => (
-                <td key={i} className="text-right px-3 py-2 text-sm text-yellow-400/80">
-                  ({fmtCurrency(s.stripe)})
-                </td>
-              ))}
-            </tr>
-
-            {/* Nocturn fees */}
-            <tr className="hover:bg-white/[0.02] transition-colors">
-              <td className="px-4 py-2">
-                <p className="text-sm text-muted-foreground">Nocturn</p>
-                <p className="text-[11px] text-muted-foreground/50">7% + $0.50/tix · buyer pays</p>
-              </td>
-              {scenarios.map((s, i) => (
-                <td key={i} className="text-right px-3 py-2 text-sm text-yellow-400/80">
-                  ({fmtCurrency(s.nocturn)})
-                </td>
-              ))}
             </tr>
 
             {/* Expenses section (if budget entered) */}
@@ -853,7 +839,7 @@ function InlinePnL({ tiers, totalExpenses = 0 }: { tiers: TicketTier[]; totalExp
           </p>
         ) : (
           <p className="text-[11px] text-muted-foreground/50">
-            Add expenses in the next step to see profit
+            Go back to Budget to add expenses and see profit
           </p>
         )}
         <p className="text-[11px] text-muted-foreground/40 shrink-0">
@@ -876,9 +862,6 @@ function LiveForecast({ tiers, totalExpenses = 0, onTiersUpdate }: { tiers: Tick
     }
   }, [tiers, priceMultiplier]);
 
-  const STRIPE_FEE_RATE = 0.029;
-  const STRIPE_FEE_FLAT = 0.30;
-
   const totalCapacity = tiers.reduce((s, t) => s + t.capacity, 0);
   const maxRevenue = tiers.reduce((s, t) => s + t.price * t.capacity, 0);
   const avgPrice = totalCapacity > 0 ? maxRevenue / totalCapacity : 0;
@@ -897,10 +880,9 @@ function LiveForecast({ tiers, totalExpenses = 0, onTiersUpdate }: { tiers: Tick
   function calcNet(rate: number) {
     const ticketsSold = Math.round(totalCapacity * rate);
     const gross = tiers.reduce((s, t) => s + t.price * Math.round(t.capacity * rate), 0);
-    const stripeProcessing = ticketsSold * STRIPE_FEE_FLAT + gross * STRIPE_FEE_RATE;
-    const netRevenue = gross - stripeProcessing;
-    const profit = netRevenue - totalExpenses;
-    return { ticketsSold, gross, net: netRevenue, profit };
+    // Organizer keeps 100% of ticket price — buyer covers platform fees, Nocturn absorbs Stripe.
+    const profit = gross - totalExpenses;
+    return { ticketsSold, gross, net: gross, profit };
   }
 
   const scenarios = [
@@ -1043,8 +1025,8 @@ function LiveForecast({ tiers, totalExpenses = 0, onTiersUpdate }: { tiers: Tick
 
       <p className="text-[11px] text-muted-foreground text-center">
         {totalExpenses > 0
-          ? `Profit = revenue \u2212 $${totalExpenses.toLocaleString()} expenses \u2212 Stripe fees (2.9% + $0.30)`
-          : "Net after Stripe fees (2.9% + $0.30) \u2022 You keep 100% of ticket price"}
+          ? `Profit = revenue \u2212 $${totalExpenses.toLocaleString()} expenses \u2022 You keep 100%, buyer covers fees`
+          : "You keep 100% of ticket price \u2022 Buyer covers platform fees at checkout"}
       </p>
     </div>
   );
@@ -2095,6 +2077,16 @@ export default function NewEventPage() {
               <p className="text-sm text-muted-foreground">How much are tickets?</p>
             </div>
 
+            {/* Attribution: tiers were suggested from the budget step */}
+            {budgetResult && budgetResult.suggestedTiers.length > 0 && tiers.length > 0 && (
+              <div className="flex items-start gap-2 rounded-xl border border-nocturn/20 bg-nocturn/[0.05] px-3 py-2.5 animate-fade-in">
+                <Sparkles className="h-3.5 w-3.5 text-nocturn shrink-0 mt-0.5" />
+                <p className="text-[12px] text-zinc-300 leading-snug">
+                  Tiers suggested from your ${totalExpenses.toLocaleString()} budget. Edit freely.
+                </p>
+              </div>
+            )}
+
             <div className="rounded-2xl border border-white/[0.06] bg-card p-5 space-y-5">
               {/* Mode reminder + shortcut */}
               <div className="flex items-center justify-between text-xs text-muted-foreground">
@@ -2418,6 +2410,18 @@ export default function NewEventPage() {
                   )}
                 </div>
               )}
+
+              {/* Market pricing sanity-check — sits next to the cost-plus suggestion
+                  so operators don't anchor on expense-driven prices without seeing
+                  what the local market is actually charging. */}
+              {budgetResult && formData.venueCity && formData.date && budgetResult.suggestedTiers.length > 0 && (
+                <PricingInsight
+                  city={formData.venueCity}
+                  date={formData.date}
+                  venueCapacity={typeof formData.venueCapacity === "number" ? formData.venueCapacity : undefined}
+                  tiers={budgetResult.suggestedTiers.map(t => ({ name: t.name, price: t.price, capacity: t.capacity }))}
+                />
+              )}
             </div>
           </div>
         )}
@@ -2602,7 +2606,7 @@ export default function NewEventPage() {
                 disabled={!canAdvance()}
                 className="flex-1 bg-nocturn hover:bg-[#6B1FE7] text-white min-h-[44px] rounded-xl transition-all duration-200 active:scale-[0.98] disabled:opacity-40 disabled:cursor-not-allowed"
               >
-                {step === "budget" ? "Review" : "Next"}
+                {currentIdx === activeSteps.length - 2 ? "Review" : "Next"}
               </Button>
             </div>
             {/* Quick jump back to review if user has been there */}

--- a/src/app/actions/ai-email.ts
+++ b/src/app/actions/ai-email.ts
@@ -36,7 +36,7 @@ export async function generatePostEventEmail(eventId: string) {
     .eq("id", eventId)
     .is("deleted_at", null)
     .maybeSingle();
-  const event = eventRaw as { id: string; title: string; slug: string; starts_at: string; collectives: { name: string; slug: string } | null; venues: { name: string; city: string } | null; [key: string]: unknown } | null;
+  const event = eventRaw as { id: string; title: string; slug: string; starts_at: string; collective_id: string | null; collectives: { name: string; slug: string } | null; venues: { name: string; city: string } | null; [key: string]: unknown } | null;
 
   if (eventError) {
     console.error("[generatePostEventEmail] event lookup failed:", eventError);
@@ -44,18 +44,16 @@ export async function generatePostEventEmail(eventId: string) {
   }
   if (!event) return { error: "Event not found", email: null };
 
-  // Verify ownership
-  const { data: evForCol } = await admin.from("events").select("collective_id").eq("id", eventId).is("deleted_at", null).maybeSingle();
-  const colId = evForCol?.collective_id;
-  if (colId) {
-    const { count: memberCount } = await admin
-      .from("collective_members")
-      .select("*", { count: "exact", head: true })
-      .eq("collective_id", colId)
-      .eq("user_id", user.id)
-      .is("deleted_at", null);
-    if (!memberCount) return { error: "Not authorized", email: null };
-  }
+  // Verify ownership — collective_id must be present; a null/missing value is not bypassed
+  const colId = event.collective_id;
+  if (!colId) return { error: "Not authorized", email: null };
+  const { count: memberCount } = await admin
+    .from("collective_members")
+    .select("*", { count: "exact", head: true })
+    .eq("collective_id", colId)
+    .eq("user_id", user.id)
+    .is("deleted_at", null);
+  if (!memberCount) return { error: "Not authorized", email: null };
 
   // Get ticket stats
   const { count: ticketsSold } = await admin
@@ -194,17 +192,16 @@ export async function generatePromoEmail(eventId: string) {
     }
     if (!event) return { error: "Event not found", email: null };
 
-    // Verify ownership — user must be a member of the event's collective
+    // Verify ownership — collective_id must be present; a null/missing value is not bypassed
     const colId = event.collective_id;
-    if (colId) {
-      const { count: memberCount } = await admin
-        .from("collective_members")
-        .select("*", { count: "exact", head: true })
-        .eq("collective_id", colId)
-        .eq("user_id", user.id)
-        .is("deleted_at", null);
-      if (!memberCount) return { error: "Not authorized", email: null };
-    }
+    if (!colId) return { error: "Not authorized", email: null };
+    const { count: memberCount } = await admin
+      .from("collective_members")
+      .select("*", { count: "exact", head: true })
+      .eq("collective_id", colId)
+      .eq("user_id", user.id)
+      .is("deleted_at", null);
+    if (!memberCount) return { error: "Not authorized", email: null };
 
     const { data: tiersRaw } = await admin
       .from("ticket_tiers")

--- a/src/app/actions/budget-planner.ts
+++ b/src/app/actions/budget-planner.ts
@@ -1,7 +1,6 @@
 "use server";
 
 import { createClient as createServerClient } from "@/lib/supabase/server";
-import { PLATFORM_FEE_PERCENT, PLATFORM_FEE_FLAT_CENTS } from "@/lib/pricing";
 
 export interface BudgetInput {
   headlinerType: "local" | "international" | "none";
@@ -142,16 +141,13 @@ export async function calculateBudget(input: BudgetInput): Promise<BudgetResult>
 
     const capacity = input.venueCapacity ?? 200;
 
-    // Calculate break-even price
-    const PLATFORM_FEE_RATE = PLATFORM_FEE_PERCENT / 100;
-    const PLATFORM_FEE_FLAT = PLATFORM_FEE_FLAT_CENTS / 100;
-    const STRIPE_FEE_RATE = 0.029;
-    const STRIPE_FEE_FLAT = 0.30;
-
-    // Target 75% sell-through for safety
+    // Calculate break-even price.
+    // Organizer keeps 100% of ticket price — buyer pays Nocturn's 7%+$0.50 service fee
+    // on top at checkout, and Nocturn absorbs Stripe processing. So no fee gross-up here.
+    // Target 75% sell-through for safety.
     const targetTickets = Math.round(capacity * 0.75);
     const breakEvenPrice = targetTickets > 0
-      ? Math.ceil((totalExpenses / targetTickets + PLATFORM_FEE_FLAT + STRIPE_FEE_FLAT) / (1 - PLATFORM_FEE_RATE - STRIPE_FEE_RATE))
+      ? Math.ceil(totalExpenses / targetTickets)
       : 0;
 
     // Suggest tiers

--- a/src/app/actions/chat-members.ts
+++ b/src/app/actions/chat-members.ts
@@ -3,6 +3,7 @@
 import { createClient as createServerClient } from "@/lib/supabase/server";
 import { createAdminClient } from "@/lib/supabase/config";
 import { revalidatePath } from "next/cache";
+import { sanitizePostgRESTInput } from "@/lib/utils";
 
 // Types
 export interface ChatMember {
@@ -158,7 +159,6 @@ export async function getChannelMembers(
 /**
  * Add a user to a channel. Caller must be admin or manager of the collective.
  */
-// TODO(audit): validate role against ["member","admin"] enum
 export async function addChannelMember(
   channelId: string,
   userId: string,
@@ -167,6 +167,9 @@ export async function addChannelMember(
   try {
     if (!channelId?.trim() || !userId?.trim()) {
       return { error: "Channel ID and user ID are required" };
+    }
+    if (!["member", "admin"].includes(role)) {
+      return { error: "Invalid role" };
     }
 
     const user = await getAuthenticatedUser();
@@ -350,18 +353,10 @@ export async function searchInvitableUsers(
       .is("deleted_at", null);
 
     if (query?.trim()) {
-      // TODO(audit): replace inline sanitizer with shared sanitizePostgRESTInput() from @/lib/utils + length cap
-      const sanitized = query
-        .replace(/\\/g, "")
-        .replace(/[%_.,()'"`]/g, "")
-        .trim();
+      const sanitized = sanitizePostgRESTInput(query.slice(0, 100));
       if (sanitized) {
-        const escaped = sanitized
-          .replace(/\\/g, "\\\\")
-          .replace(/%/g, "\\%")
-          .replace(/_/g, "\\_");
         teamQuery = teamQuery.or(
-          `users.full_name.ilike.%${escaped}%,users.email.ilike.%${escaped}%`
+          `users.full_name.ilike.%${sanitized}%,users.email.ilike.%${sanitized}%`
         );
       }
     }
@@ -440,24 +435,16 @@ export async function searchInvitableUsers(
 
     // For event channels with a search query, also search platform-wide artists and collectives
     if (channel.type === "event" && query?.trim()) {
-      const sanitized = query
-        .replace(/\\/g, "")
-        .replace(/[%_.,()'"`]/g, "")
-        .trim();
+      const sanitized = sanitizePostgRESTInput(query.slice(0, 100));
 
       if (sanitized) {
-        const escaped = sanitized
-          .replace(/\\/g, "\\\\")
-          .replace(/%/g, "\\%")
-          .replace(/_/g, "\\_");
-        const _lowerQuery = sanitized.toLowerCase();
 
         // Search platform artists by name (PostgREST .or() can't cross into joined tables)
         const { data: platformArtists } = await sb
           .from("artists")
           .select("id, user_id, name, users!inner(id, full_name, email)")
           .not("user_id", "is", null)
-          .ilike("name", `%${escaped}%`)
+          .ilike("name", `%${sanitized}%`)
           .limit(20);
 
         if (platformArtists) {
@@ -485,7 +472,7 @@ export async function searchInvitableUsers(
           .from("artists")
           .select("id, user_id, name, users!inner(id, full_name, email)")
           .not("user_id", "is", null)
-          .or(`full_name.ilike.%${escaped}%,email.ilike.%${escaped}%`, { referencedTable: "users" })
+          .or(`full_name.ilike.%${sanitized}%,email.ilike.%${sanitized}%`, { referencedTable: "users" })
           .limit(20);
 
         if (platformArtistsByUser) {
@@ -512,7 +499,7 @@ export async function searchInvitableUsers(
         const { data: platformCollectives } = await sb
           .from("collectives")
           .select("id, name, collective_members!inner(user_id, role, users!inner(id, full_name, email))")
-          .ilike("name", `%${escaped}%`)
+          .ilike("name", `%${sanitized}%`)
           .neq("id", channel.collective_id)
           .limit(10);
 

--- a/src/app/actions/promo-codes.ts
+++ b/src/app/actions/promo-codes.ts
@@ -77,7 +77,6 @@ function toPromoCode(row: Record<string, unknown>): PromoCode {
   };
 }
 
-// TODO(audit): bound maxUses 1-100000, validate expiresAt as real date
 export async function createPromoCode(input: {
   eventId: string;
   code: string;
@@ -94,6 +93,25 @@ export async function createPromoCode(input: {
 
     const access = await verifyEventAccess(input.eventId);
     if (access.error) return { error: access.error };
+    if (input.maxUses !== null && input.maxUses !== undefined) {
+      if (!Number.isInteger(input.maxUses) || input.maxUses < 1 || input.maxUses > 100_000) {
+        return { error: "maxUses must be an integer between 1 and 100,000" };
+      }
+    }
+    if (input.expiresAt !== null && input.expiresAt !== undefined) {
+      if (isNaN(Date.parse(input.expiresAt))) {
+        return { error: "expiresAt must be a valid ISO date" };
+      }
+      const expiresDate = new Date(input.expiresAt);
+      const now = new Date();
+      const twoYearsOut = new Date(now.getFullYear() + 2, now.getMonth(), now.getDate());
+      if (expiresDate <= now) {
+        return { error: "expiresAt must be in the future" };
+      }
+      if (expiresDate > twoYearsOut) {
+        return { error: "expiresAt cannot be more than 2 years in the future" };
+      }
+    }
 
     // Rate limit: 10 promo code operations per minute per user
     const { success: rlOk } = await rateLimitStrict(`promo:${access.userId}`, 10, 60_000);

--- a/src/app/api/cron/cleanup-pending-tickets/route.ts
+++ b/src/app/api/cron/cleanup-pending-tickets/route.ts
@@ -16,7 +16,6 @@ function safeCompare(a: string, b: string): boolean {
  */
 export async function GET(request: NextRequest) {
   // Verify cron secret to prevent unauthorized access.
-  // TODO(audit): log successful auth for audit trail
   const authHeader = request.headers.get("authorization") ?? "";
   const cronSecret = process.env.CRON_SECRET;
   if (!cronSecret) {
@@ -26,6 +25,7 @@ export async function GET(request: NextRequest) {
   if (!safeCompare(authHeader, `Bearer ${cronSecret}`)) {
     return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
   }
+  console.info(`[cleanup-pending-tickets] cron triggered at ${new Date().toISOString()}`);
 
   const supabase = createAdminClient();
 
@@ -46,12 +46,11 @@ export async function GET(request: NextRequest) {
 
     const count = deleted?.length ?? 0;
     if (count > 0) {
-      console.info(`[cleanup-pending-tickets] Cleaned up ${count} expired pending ticket(s)`);
-
       // Release promo claims for expired pending tickets if they had promos
       // (Promo claims are released on payment_intent.payment_failed, but abandoned checkouts
       // where the user just closes the tab never trigger that webhook)
     }
+    console.info(`[cleanup-pending-tickets] completed — cleaned ${count} expired pending ticket(s)`);
 
     return NextResponse.json({ cleaned: count });
   } catch (err) {

--- a/src/app/api/generate-poster/route.ts
+++ b/src/app/api/generate-poster/route.ts
@@ -1,7 +1,9 @@
 import { NextRequest, NextResponse } from "next/server";
 import { createClient } from "@/lib/supabase/server";
+import { createAdminClient } from "@/lib/supabase/config";
 import Replicate from "replicate";
 import { rateLimitStrict } from "@/lib/rate-limit";
+import { generatePosterPrompt } from "@/app/actions/ai-poster";
 
 const REPLICATE_API_TOKEN = process.env.REPLICATE_API_TOKEN;
 
@@ -64,23 +66,69 @@ export async function POST(request: NextRequest) {
     );
   }
 
-  // TODO(audit): client sends arbitrary prompt bypassing server-side generatePosterPrompt. Require HMAC-signed prompt or regenerate server-side.
-  let prompt: string;
+  // Accept eventId + optional structured params; regenerate prompt server-side
+  let eventId: string;
+  let clientVibeTags: string[] | undefined;
+  let clientVenueName: string | undefined;
+  let clientStyleDirection: string | undefined;
   try {
     const body = await request.json();
-    prompt = body.prompt;
+    eventId = body.eventId;
+    clientVibeTags = Array.isArray(body.vibeTags)
+      ? (body.vibeTags as unknown[]).filter((t): t is string => typeof t === "string").slice(0, 10)
+      : undefined;
+    clientVenueName = typeof body.venueName === "string" ? body.venueName.slice(0, 100) : undefined;
+    clientStyleDirection = typeof body.styleDirection === "string" ? body.styleDirection.slice(0, 200) : undefined;
   } catch {
     return NextResponse.json({ error: "Invalid JSON body" }, { status: 400 });
   }
 
-  try {
-    if (typeof prompt !== "string" || prompt.length > 2000) {
-      return NextResponse.json({ error: "Invalid or too-long prompt (max 2000 chars)" }, { status: 400 });
-    }
-    if (!prompt) {
-      return NextResponse.json({ error: "Missing prompt" }, { status: 400 });
-    }
+  const uuidRegex = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+  if (!eventId || !uuidRegex.test(eventId)) {
+    return NextResponse.json({ error: "Missing or invalid eventId" }, { status: 400 });
+  }
 
+  // Fetch event and verify the authenticated user is a collective member
+  const admin = createAdminClient();
+  const { data: eventRow } = await admin
+    .from("events")
+    .select("title, vibe_tags, collective_id, venues(name, city)")
+    .eq("id", eventId)
+    .is("deleted_at", null)
+    .maybeSingle();
+
+  if (!eventRow) {
+    return NextResponse.json({ error: "Event not found" }, { status: 404 });
+  }
+
+  const ev = eventRow as unknown as { title: string; vibe_tags: string[] | null; collective_id: string; venues: { name: string; city: string } | null };
+
+  const { count: memberCount } = await admin
+    .from("collective_members")
+    .select("*", { count: "exact", head: true })
+    .eq("collective_id", ev.collective_id)
+    .eq("user_id", authedUserId)
+    .is("deleted_at", null);
+
+  if (!memberCount) {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 403 });
+  }
+
+  // Generate prompt server-side from structured event data
+  const venue = ev.venues;
+  const { prompt, error: promptError } = await generatePosterPrompt({
+    title: ev.title,
+    genre: clientVibeTags ?? (ev.vibe_tags || []),
+    venueName: clientVenueName ?? venue?.name,
+    city: venue?.city,
+    styleDirection: clientStyleDirection,
+  });
+
+  if (promptError || !prompt) {
+    return NextResponse.json({ error: "Failed to generate poster prompt" }, { status: 500 });
+  }
+
+  try {
     const replicate = new Replicate({ auth: REPLICATE_API_TOKEN });
     let imageUrl: string | null = null;
 

--- a/src/app/onboarding/page.tsx
+++ b/src/app/onboarding/page.tsx
@@ -50,6 +50,7 @@ export default function OnboardingPage() {
   const [error, setError] = useState<string | null>(null);
   const [authChecked, setAuthChecked] = useState(false);
   const [isPaidEvent, setIsPaidEvent] = useState(false);
+  const [isSubmitting, setIsSubmitting] = useState(false);
 
   // Live name availability check (debounced).
   // "idle" = nothing typed yet or just changed; "checking" = request in flight;
@@ -148,6 +149,7 @@ export default function OnboardingPage() {
   }
 
   async function handleCreate(skipEventOverride?: boolean) {
+    setIsSubmitting(true);
     setStep("creating");
     setError(null);
 
@@ -173,6 +175,7 @@ export default function OnboardingPage() {
 
     if (result.error) {
       setError(result.error);
+      setIsSubmitting(false);
       const isNameConflict = result.error.toLowerCase().includes("already taken");
       // Name conflict → back to Screen 1 to edit the name.
       // Anything else → back to wherever they were so they can retry.
@@ -400,7 +403,7 @@ export default function OnboardingPage() {
 
               <Button
                 onClick={() => handleCreate()}
-                disabled={step === "creating"}
+                disabled={isSubmitting}
                 className="w-full bg-nocturn hover:bg-nocturn-light py-5 text-base min-h-[48px]"
               >
                 <Sparkles className="mr-2 h-4 w-4" />

--- a/src/app/onboarding/page.tsx
+++ b/src/app/onboarding/page.tsx
@@ -74,9 +74,12 @@ export default function OnboardingPage() {
           // Restore date as Date object
           setEventData({ ...data.eventData, date: new Date(data.eventData.date) });
         }
-        // Restore to the step they were on (but not "creating" or "share")
+        // Restore to the step they were on (but not "creating" or "share").
+        // If step is "event" but eventData didn't restore, fall back to "vibe"
+        // to avoid a blank screen with no CTA.
         if (data.step && data.step !== "creating" && data.step !== "share") {
-          setStep(data.step);
+          const restoredStep = data.step === "event" && !data.eventData ? "vibe" : data.step;
+          setStep(restoredStep);
         }
       }
     } catch {}
@@ -144,7 +147,7 @@ export default function OnboardingPage() {
     setEventData(createInitialEventData(vibe, name));
   }
 
-  async function handleCreate() {
+  async function handleCreate(skipEventOverride?: boolean) {
     setStep("creating");
     setError(null);
 
@@ -178,7 +181,9 @@ export default function OnboardingPage() {
     }
 
     // 2. Create event (if not skipped)
-    if (!skipEvent && eventData) {
+    // Use skipEventOverride when passed (avoids stale-closure issue from handleSkipEvent)
+    const shouldSkip = skipEventOverride ?? skipEvent;
+    if (!shouldSkip && eventData) {
       const eventResult = await createOnboardingEvent({
         collectiveSlug: slug,
         title: eventData.title,
@@ -199,7 +204,7 @@ export default function OnboardingPage() {
     }
 
     // Track if this is a paid event (created as draft, not live)
-    if (!skipEvent && eventData && eventData.tierPrice > 0) {
+    if (!shouldSkip && eventData && eventData.tierPrice > 0) {
       setIsPaidEvent(true);
     }
 
@@ -209,7 +214,9 @@ export default function OnboardingPage() {
 
   function handleSkipEvent() {
     setSkipEvent(true);
-    handleCreate();
+    // Pass skip=true explicitly — React state update is async so skipEvent
+    // would still be false inside handleCreate if we relied on the state value.
+    handleCreate(true);
   }
 
   function goToDashboard() {
@@ -218,7 +225,7 @@ export default function OnboardingPage() {
     router.refresh();
   }
 
-  const currentStep = step === "name_city" ? 1 : step === "vibe" ? 2 : step === "event" ? 3 : step === "share" ? 3 : 0;
+  const currentStep = step === "name_city" ? 1 : step === "vibe" ? 2 : step === "event" ? 3 : step === "creating" ? 3 : step === "share" ? 3 : 0;
   const totalSteps = 3;
 
   // Show loading spinner until auth check completes
@@ -393,6 +400,7 @@ export default function OnboardingPage() {
 
               <Button
                 onClick={() => handleCreate()}
+                disabled={step === "creating"}
                 className="w-full bg-nocturn hover:bg-nocturn-light py-5 text-base min-h-[48px]"
               >
                 <Sparkles className="mr-2 h-4 w-4" />

--- a/src/components/onboarding/share-screen.tsx
+++ b/src/components/onboarding/share-screen.tsx
@@ -31,15 +31,9 @@ export function ShareScreen({ eventTitle, collectiveSlug, eventSlug, isPaidEvent
       setCopied(true);
       setTimeout(() => setCopied(false), 2000);
     } catch {
-      // Fallback for mobile
-      const input = document.createElement("input");
-      input.value = shareUrl;
-      document.body.appendChild(input);
-      input.select();
-      document.execCommand("copy");
-      document.body.removeChild(input);
-      setCopied(true);
-      setTimeout(() => setCopied(false), 2000);
+      // Clipboard API unavailable (non-secure context or browser restriction).
+      // document.execCommand("copy") is deprecated and unreliable — don't use it.
+      // Leave copied=false so the user sees the URL to long-press/copy manually.
     }
   }
 


### PR DESCRIPTION
## Day 3 Afternoon — Onboarding + QR Check-in Hardening

Auto-generated by the scheduled hardening agent.

### Part A — Onboarding fixes

| # | Severity | Issue | Fix |
|---|----------|-------|-----|
| 1 | **High** | `handleSkipEvent` stale-closure race: `setSkipEvent(true)` + `handleCreate()` reads old state, creating an event even when user clicks "I'll do this later" | `handleCreate(skipEventOverride?)` param; `handleSkipEvent` passes `true` explicitly |
| 2 | **Medium** | Blank screen trap: localStorage restores `step="event"` but `eventData` null → no CTA, no back button | Fall back to `"vibe"` step on restore when `eventData` missing |
| 3 | **Medium** | No `disabled` on Create Event button — double-tap creates duplicate collective/event | `isSubmitting` state, set on entry, cleared on error |
| 4 | **Low** | Progress bar vanishes during "creating" step (`currentStep = 0`) | Map `"creating"` → `currentStep = 3` |
| 5 | **Low** | `document.execCommand("copy")` deprecated in share-screen clipboard fallback | Removed; clipboard failure now leaves `copied=false` |

### Part B — QR check-in fixes

| # | Severity | Issue | Fix |
|---|----------|-------|-----|
| 1 | **High** | `handleScan` useCallback closure captures stale `muted` — mute toggle silently broken after first scan | `mutedRef` mirroring `muted` state (same pattern as `pausedRef` in QrScanner); reads `mutedRef.current` inside callback |
| 2 | **Medium** | `loadDoorList` silently fails (no error feedback when query fails) | Added `doorListError` state + try/catch; error banner shown in UI |
| 3 | **Low** | `offlineQueue.length + 1` stale count in queued message | Replaced with stable "Will sync when back online" text |
| 4 | **Low** | `loadDoorList` recreated on every render (not `useCallback`) | Wrapped in `useCallback([eventId])` |

### Gates
- ✅ `npm run build` — clean
- ✅ `npm run test` — 88/88 passed
- ⏭️ `test:e2e` — skipped (baseline not yet generated per protocol)

🤖 Generated with [Claude Code](https://claude.com/claude-code)