### PR TITLE
feat(budget): multi-currency event budget with itemized expense intake

### DIFF
--- a/src/app/(dashboard)/dashboard/events/new/page.tsx
+++ b/src/app/(dashboard)/dashboard/events/new/page.tsx
@@ -5,7 +5,16 @@ import { useRouter } from "next/navigation";
 import { createEvent } from "@/app/actions/events";
 import { type TicketTier } from "@/app/actions/ai-parse-event";
 import { getTicketPricingSuggestion, type PricingSuggestion } from "@/app/actions/pricing-suggestion";
-import { calculateBudget, type BudgetResult, type BudgetInput } from "@/app/actions/budget-planner";
+import {
+  calculateBudget,
+  suggestTravel,
+  type BudgetResult,
+  type BudgetInput,
+  type ExpenseItem,
+  type ExpenseCategory,
+} from "@/app/actions/budget-planner";
+import { SUPPORTED_CURRENCIES } from "@/lib/currency";
+import { getMyCollectiveDefaults } from "@/app/actions/collective-settings";
 import { applyLaunchPlaybook } from "@/app/actions/launch-playbook";
 import { createClient } from "@/lib/supabase/client";
 import { trackEvent } from "@/lib/track";
@@ -65,10 +74,94 @@ function buyerTotal(ticketPrice: number): number {
   return ticketPrice + ticketPrice * BUYER_FEE_RATE + BUYER_FEE_FLAT;
 }
 
+// ─── Budget draft (client-side state shape) ─────────────────────────────────
+// The Budget step used to collect a handful of flat numbers (talentFee,
+// venueCost, etc.). Now it's itemized with per-row currency so international
+// DJ fees in USD can coexist with local venue costs in CAD. `flattenBudget()`
+// walks this tree and produces the ExpenseItem[] the server action expects.
+
+interface AmountInCurrency {
+  amount: number;
+  currency: string; // ISO 4217 lowercase
+}
+
+interface BudgetDraft {
+  eventCurrency: string; // e.g. "cad"; falls back to collective default, then "usd"
+  headliner: {
+    type: "local" | "international" | "none";
+    origin: string;
+    stayNights: number;
+  };
+  talentFee: AmountInCurrency;
+  // Travel rows only shown for international; amounts may be zero when skipped
+  travel: {
+    flights: AmountInCurrency;
+    hotel: AmountInCurrency;
+    transport: AmountInCurrency;
+    perDiem: AmountInCurrency;
+  };
+  // Venue costs are always assumed in the event currency (paid to local vendor)
+  venueRental: number;
+  barMinimum: number;
+  deposit: number;
+  // Dynamic rows from the chip-add Production & Marketing section
+  prodItems: Array<{
+    category: ExpenseCategory;
+    label: string;
+    amount: number;
+    currency: string;
+  }>;
+}
+
+function defaultBudgetDraft(eventCurrency = "usd"): BudgetDraft {
+  return {
+    eventCurrency,
+    headliner: { type: "none", origin: "", stayNights: 2 },
+    talentFee: { amount: 0, currency: eventCurrency },
+    travel: {
+      flights: { amount: 0, currency: eventCurrency },
+      hotel: { amount: 0, currency: eventCurrency },
+      transport: { amount: 0, currency: eventCurrency },
+      perDiem: { amount: 0, currency: eventCurrency },
+    },
+    venueRental: 0,
+    barMinimum: 0,
+    deposit: 0,
+    prodItems: [],
+  };
+}
+
+function flattenBudget(draft: BudgetDraft): ExpenseItem[] {
+  const items: ExpenseItem[] = [];
+  const push = (category: ExpenseCategory, label: string, a: AmountInCurrency) => {
+    if (a.amount > 0) items.push({ category, label, amount: a.amount, currency: a.currency });
+  };
+
+  if (draft.headliner.type !== "none") {
+    push("talent", "Talent fee", draft.talentFee);
+  }
+  if (draft.headliner.type === "international") {
+    push("flights", "Flights", draft.travel.flights);
+    push("hotel", "Hotel", draft.travel.hotel);
+    push("transport", "Transport", draft.travel.transport);
+    push("per_diem", "Per diem", draft.travel.perDiem);
+  }
+  if (draft.venueRental > 0) {
+    items.push({ category: "venue_rental", label: "Venue rental", amount: draft.venueRental, currency: draft.eventCurrency });
+  }
+  if (draft.deposit > 0) {
+    items.push({ category: "deposit", label: "Venue deposit", amount: draft.deposit, currency: draft.eventCurrency });
+  }
+  for (const p of draft.prodItems) {
+    if (p.amount > 0) items.push({ category: p.category, label: p.label, amount: p.amount, currency: p.currency });
+  }
+  return items;
+}
+
 // ─── Draft Persistence ─────────────────────────────────────────────────────
 
 const DRAFT_STORAGE_KEY = "nocturn-event-draft";
-const DRAFT_VERSION = 3;
+const DRAFT_VERSION = 4;
 
 type WizardStep = "details" | "venue" | "tickets" | "budget" | "review";
 
@@ -93,7 +186,7 @@ interface DraftState {
   step: WizardStep;
   formData: EventFormData;
   tiers: TicketTier[];
-  budgetInput: Partial<BudgetInput>;
+  budgetDraft: BudgetDraft;
   budgetResult: BudgetResult | null;
   phase: "wizard" | "creating" | "playbook" | "done";
 }
@@ -1207,6 +1300,477 @@ function FormField({ label, icon: Icon, required, children }: {
   );
 }
 
+// ─── Budget Step ────────────────────────────────────────────────────────────
+// Multi-currency budget intake. Each expense row has its own currency;
+// everything converts to the event's currency at entry time for the P&L math.
+
+interface MoneyRowProps {
+  label: string;
+  placeholder?: string;
+  value: AmountInCurrency;
+  onChange: (v: AmountInCurrency) => void;
+  eventCurrency: string; // used for the "≈ converted" hint
+  Icon?: React.ComponentType<{ className?: string }>;
+  onDelete?: () => void;
+}
+
+function MoneyRow({ label, placeholder, value, onChange, eventCurrency, Icon, onDelete }: MoneyRowProps) {
+  // No client-side FX here — we'd need to ship rates to the browser. The
+  // "≈ converted" hint fires when the user taps Calculate Budget (result
+  // shows resolved local amounts). Keeps the form fast and predictable.
+  const showFxHint = value.currency.toLowerCase() !== eventCurrency.toLowerCase() && value.amount > 0;
+
+  return (
+    <div className="space-y-1">
+      <div className="flex items-center justify-between">
+        <label className="flex items-center gap-1.5 text-xs text-muted-foreground">
+          {Icon && <Icon className="h-3 w-3 text-nocturn" />}
+          {label}
+        </label>
+        {onDelete && (
+          <button
+            onClick={onDelete}
+            aria-label={`Remove ${label}`}
+            className="text-muted-foreground/40 hover:text-red-400 transition-colors min-h-[28px] min-w-[28px] flex items-center justify-center"
+          >
+            <Trash2 className="h-3 w-3" />
+          </button>
+        )}
+      </div>
+      <div className="flex gap-1.5">
+        <Input
+          type="number"
+          inputMode="decimal"
+          placeholder={placeholder ?? "0"}
+          value={value.amount || ""}
+          onChange={(e) => onChange({ ...value, amount: parseFloat(e.target.value) || 0 })}
+          className="bg-zinc-900 border-white/10 rounded-lg min-h-[40px] focus:border-nocturn/50 flex-1"
+        />
+        <select
+          value={value.currency}
+          onChange={(e) => onChange({ ...value, currency: e.target.value })}
+          aria-label={`${label} currency`}
+          className="bg-zinc-900 border border-white/10 rounded-lg px-2 text-sm text-white focus:border-nocturn/50 focus:outline-none min-h-[40px] min-w-[72px]"
+        >
+          {SUPPORTED_CURRENCIES.map(c => (
+            <option key={c.code} value={c.code}>{c.code.toUpperCase()}</option>
+          ))}
+        </select>
+      </div>
+      {showFxHint && (
+        <p className="text-[10px] text-muted-foreground/60">
+          Converts to {eventCurrency.toUpperCase()} when you tap Calculate
+        </p>
+      )}
+    </div>
+  );
+}
+
+// Chip-add row definitions for Production & Marketing. One tap adds a row
+// with the label + default category prefilled; operator fills amount + currency.
+const PROD_CHIPS: Array<{ category: ExpenseCategory; label: string; icon: React.ComponentType<{ className?: string }> }> = [
+  { category: "ads",             label: "Ads",             icon: Megaphone },
+  { category: "graphic_design",  label: "Graphic design",  icon: Sparkles },
+  { category: "photo",           label: "Photo",           icon: Sparkles },
+  { category: "video",           label: "Video",           icon: Sparkles },
+];
+
+interface BudgetStepProps {
+  draft: BudgetDraft;
+  setDraft: React.Dispatch<React.SetStateAction<BudgetDraft>>;
+  result: BudgetResult | null;
+  calculating: boolean;
+  venueCity: string;
+  eventDate: string;
+  venueCapacity: number | undefined;
+  onSkip: () => void;
+  onCalculate: () => void;
+  onSuggestTravel: () => void;
+  tiers: TicketTier[];
+  onApplySuggestedTiers: () => void;
+}
+
+function BudgetStep({
+  draft, setDraft, result, calculating,
+  venueCity, eventDate, venueCapacity,
+  onSkip, onCalculate, onSuggestTravel,
+  tiers, onApplySuggestedTiers,
+}: BudgetStepProps) {
+  const ec = draft.eventCurrency;
+  const hasAnyExpense =
+    draft.talentFee.amount > 0 ||
+    draft.venueRental > 0 ||
+    draft.deposit > 0 ||
+    draft.travel.flights.amount > 0 ||
+    draft.travel.hotel.amount > 0 ||
+    draft.travel.transport.amount > 0 ||
+    draft.travel.perDiem.amount > 0 ||
+    draft.prodItems.some(p => p.amount > 0);
+
+  function updateTravel(key: keyof BudgetDraft["travel"], value: AmountInCurrency) {
+    setDraft(prev => ({ ...prev, travel: { ...prev.travel, [key]: value } }));
+  }
+
+  function addProdItem(category: ExpenseCategory, label: string) {
+    setDraft(prev => ({
+      ...prev,
+      prodItems: [...prev.prodItems, { category, label, amount: 0, currency: prev.eventCurrency }],
+    }));
+  }
+
+  function addCustomProdItem() {
+    addProdItem("other", "Custom expense");
+  }
+
+  function updateProdItem(idx: number, partial: Partial<BudgetDraft["prodItems"][number]>) {
+    setDraft(prev => ({
+      ...prev,
+      prodItems: prev.prodItems.map((p, i) => (i === idx ? { ...p, ...partial } : p)),
+    }));
+  }
+
+  function removeProdItem(idx: number) {
+    setDraft(prev => ({ ...prev, prodItems: prev.prodItems.filter((_, i) => i !== idx) }));
+  }
+
+  // Which prod chips are still available (already-added ones disappear from the tray).
+  const addedCategories = new Set(draft.prodItems.map(p => p.category));
+  const availableChips = PROD_CHIPS.filter(c => !addedCategories.has(c.category));
+
+  return (
+    <div className="space-y-5 animate-fade-in">
+      <div className="text-center space-y-1 pb-2">
+        <h2 className="text-lg font-bold font-heading bg-gradient-to-r from-[#7B2FF7] to-[#9D5CFF] bg-clip-text text-transparent">
+          Budget Planning
+        </h2>
+        <p className="text-sm text-muted-foreground">Optional — helps forecast profit</p>
+      </div>
+
+      {/* Skip shortcut */}
+      <button
+        onClick={onSkip}
+        className="w-full flex items-center justify-center gap-2 rounded-2xl border border-white/[0.06] bg-card p-4 text-sm text-zinc-400 hover:text-zinc-200 hover:border-nocturn/30 transition-all duration-200 active:scale-[0.98]"
+      >
+        <SkipForward className="h-4 w-4" />
+        Skip — I&apos;ll figure out costs later
+      </button>
+
+      <div className="rounded-2xl border border-white/[0.06] bg-card p-5 space-y-5">
+        {/* Event currency */}
+        <div className="space-y-1.5">
+          <label className="flex items-center gap-1.5 text-sm font-medium text-zinc-300">
+            <DollarSign className="h-3.5 w-3.5 text-nocturn" />
+            Report this event&apos;s budget in
+          </label>
+          <select
+            value={ec}
+            onChange={(e) => setDraft(prev => ({ ...prev, eventCurrency: e.target.value }))}
+            aria-label="Event currency"
+            className="w-full bg-zinc-900 border border-white/10 rounded-xl px-3 text-sm text-white focus:border-nocturn/50 focus:outline-none min-h-[44px]"
+          >
+            {SUPPORTED_CURRENCIES.map(c => (
+              <option key={c.code} value={c.code}>{c.label}</option>
+            ))}
+          </select>
+          <p className="text-[11px] text-muted-foreground/60">
+            Totals and profit display in this currency. Individual rows can be entered in any currency.
+          </p>
+        </div>
+
+        {/* ── Headliner ── */}
+        <div className="space-y-2 border-t border-white/5 pt-4">
+          <span className="flex items-center gap-1.5 text-sm font-medium text-zinc-300">
+            <Music className="h-3.5 w-3.5 text-nocturn" />
+            Headliner
+          </span>
+          <div className="grid grid-cols-3 gap-2" role="radiogroup" aria-label="Headliner type">
+            {([
+              { value: "international" as const, label: "International", icon: Plane },
+              { value: "local" as const,         label: "Local",         icon: Music },
+              { value: "none" as const,          label: "No headliner",  icon: Users },
+            ]).map((opt) => (
+              <button
+                key={opt.value}
+                role="radio"
+                aria-checked={draft.headliner.type === opt.value}
+                onClick={() => setDraft(prev => ({ ...prev, headliner: { ...prev.headliner, type: opt.value } }))}
+                className={`flex flex-col items-center gap-1.5 rounded-xl border p-3 text-center transition-all duration-200 active:scale-[0.98] min-h-[72px] ${
+                  draft.headliner.type === opt.value
+                    ? "border-nocturn/40 bg-nocturn/5 text-white"
+                    : "border-white/[0.06] bg-zinc-900 text-zinc-400 hover:border-nocturn/30 hover:text-zinc-200"
+                }`}
+              >
+                <opt.icon className="h-4 w-4" />
+                <span className="text-xs font-medium">{opt.label}</span>
+              </button>
+            ))}
+          </div>
+
+          {draft.headliner.type !== "none" && (
+            <div className="space-y-3 pt-2 animate-fade-in">
+              {draft.headliner.type === "international" && (
+                <>
+                  <FormField label="Flying from" icon={Plane}>
+                    <Input
+                      placeholder="London, UK"
+                      value={draft.headliner.origin}
+                      onChange={(e) => setDraft(prev => ({ ...prev, headliner: { ...prev.headliner, origin: e.target.value } }))}
+                      className="bg-zinc-900 border-white/10 rounded-xl min-h-[44px] focus:border-nocturn/50"
+                    />
+                  </FormField>
+                  <FormField label="Stay (nights)" icon={Clock}>
+                    <Input
+                      type="number"
+                      min={0}
+                      value={draft.headliner.stayNights || ""}
+                      onChange={(e) => setDraft(prev => ({ ...prev, headliner: { ...prev.headliner, stayNights: parseInt(e.target.value) || 0 } }))}
+                      className="bg-zinc-900 border-white/10 rounded-xl min-h-[44px] focus:border-nocturn/50"
+                    />
+                  </FormField>
+                </>
+              )}
+
+              <MoneyRow
+                label="Talent fee"
+                placeholder={draft.headliner.type === "international" ? "2000" : "500"}
+                value={draft.talentFee}
+                onChange={(v) => setDraft(prev => ({ ...prev, talentFee: v }))}
+                eventCurrency={ec}
+                Icon={DollarSign}
+              />
+
+              {draft.headliner.type === "international" && (
+                <>
+                  <div className="flex items-center justify-between gap-2 pt-1">
+                    <span className="text-xs text-muted-foreground">Travel costs</span>
+                    <button
+                      type="button"
+                      onClick={onSuggestTravel}
+                      disabled={!draft.headliner.origin || !venueCity}
+                      className="text-xs text-nocturn hover:text-nocturn-light transition-colors disabled:opacity-40 disabled:cursor-not-allowed"
+                    >
+                      <Sparkles className="h-3 w-3 inline mr-1" />
+                      Auto-fill estimates
+                    </button>
+                  </div>
+                  <MoneyRow label="Flights"   value={draft.travel.flights}   onChange={(v) => updateTravel("flights", v)}   eventCurrency={ec} />
+                  <MoneyRow label="Hotel"     value={draft.travel.hotel}     onChange={(v) => updateTravel("hotel", v)}     eventCurrency={ec} />
+                  <MoneyRow label="Transport" value={draft.travel.transport} onChange={(v) => updateTravel("transport", v)} eventCurrency={ec} />
+                  <MoneyRow label="Per diem"  value={draft.travel.perDiem}   onChange={(v) => updateTravel("perDiem", v)}   eventCurrency={ec} />
+                </>
+              )}
+            </div>
+          )}
+        </div>
+
+        {/* ── Venue (all in event currency) ── */}
+        <div className="space-y-3 border-t border-white/5 pt-4">
+          <span className="flex items-center gap-1.5 text-sm font-medium text-zinc-300">
+            <Warehouse className="h-3.5 w-3.5 text-nocturn" />
+            Venue costs
+          </span>
+          <div className="grid grid-cols-2 gap-3">
+            <div className="space-y-1">
+              <label className="text-xs text-muted-foreground">Room rental</label>
+              <Input
+                type="number"
+                placeholder="0"
+                value={draft.venueRental || ""}
+                onChange={(e) => setDraft(prev => ({ ...prev, venueRental: parseInt(e.target.value) || 0 }))}
+                className="bg-zinc-900 border-white/10 rounded-lg min-h-[40px] focus:border-nocturn/50"
+              />
+            </div>
+            <div className="space-y-1">
+              <label className="text-xs text-muted-foreground">Bar minimum</label>
+              <Input
+                type="number"
+                placeholder="0"
+                value={draft.barMinimum || ""}
+                onChange={(e) => setDraft(prev => ({ ...prev, barMinimum: parseInt(e.target.value) || 0 }))}
+                className="bg-zinc-900 border-white/10 rounded-lg min-h-[40px] focus:border-nocturn/50"
+              />
+            </div>
+            <div className="space-y-1">
+              <label className="text-xs text-muted-foreground">Deposit</label>
+              <Input
+                type="number"
+                placeholder="0"
+                value={draft.deposit || ""}
+                onChange={(e) => setDraft(prev => ({ ...prev, deposit: parseInt(e.target.value) || 0 }))}
+                className="bg-zinc-900 border-white/10 rounded-lg min-h-[40px] focus:border-nocturn/50"
+              />
+            </div>
+          </div>
+          <p className="text-[11px] text-muted-foreground/60">All in {ec.toUpperCase()} — venue is paid locally.</p>
+        </div>
+
+        {/* ── Production & Marketing (chip-add) ── */}
+        <div className="space-y-3 border-t border-white/5 pt-4">
+          <span className="flex items-center gap-1.5 text-sm font-medium text-zinc-300">
+            <Megaphone className="h-3.5 w-3.5 text-nocturn" />
+            Production &amp; marketing
+          </span>
+
+          {/* Added rows */}
+          {draft.prodItems.length > 0 && (
+            <div className="space-y-3">
+              {draft.prodItems.map((p, i) => (
+                <div key={i} className="space-y-1">
+                  <div className="flex items-center justify-between">
+                    <Input
+                      value={p.label}
+                      onChange={(e) => updateProdItem(i, { label: e.target.value })}
+                      className="bg-transparent border-0 p-0 text-xs text-muted-foreground focus:outline-none focus:text-white h-auto min-h-0"
+                    />
+                    <button
+                      onClick={() => removeProdItem(i)}
+                      aria-label={`Remove ${p.label}`}
+                      className="text-muted-foreground/40 hover:text-red-400 transition-colors min-h-[28px] min-w-[28px] flex items-center justify-center"
+                    >
+                      <Trash2 className="h-3 w-3" />
+                    </button>
+                  </div>
+                  <div className="flex gap-1.5">
+                    <Input
+                      type="number"
+                      inputMode="decimal"
+                      placeholder="0"
+                      value={p.amount || ""}
+                      onChange={(e) => updateProdItem(i, { amount: parseFloat(e.target.value) || 0 })}
+                      className="bg-zinc-900 border-white/10 rounded-lg min-h-[40px] focus:border-nocturn/50 flex-1"
+                    />
+                    <select
+                      value={p.currency}
+                      onChange={(e) => updateProdItem(i, { currency: e.target.value })}
+                      aria-label={`${p.label} currency`}
+                      className="bg-zinc-900 border border-white/10 rounded-lg px-2 text-sm text-white focus:border-nocturn/50 focus:outline-none min-h-[40px] min-w-[72px]"
+                    >
+                      {SUPPORTED_CURRENCIES.map(c => (
+                        <option key={c.code} value={c.code}>{c.code.toUpperCase()}</option>
+                      ))}
+                    </select>
+                  </div>
+                </div>
+              ))}
+            </div>
+          )}
+
+          {/* Chip tray */}
+          {(availableChips.length > 0 || true) && (
+            <div className="flex flex-wrap gap-2">
+              {availableChips.map((c) => (
+                <button
+                  key={c.category}
+                  type="button"
+                  onClick={() => addProdItem(c.category, c.label)}
+                  className="flex items-center gap-1.5 rounded-full border border-white/10 bg-zinc-900 px-3 py-1.5 text-xs text-zinc-300 hover:border-nocturn/40 hover:bg-nocturn/10 hover:text-white transition-all active:scale-[0.97] min-h-[36px]"
+                >
+                  <Plus className="h-3 w-3" />
+                  {c.label}
+                </button>
+              ))}
+              <button
+                type="button"
+                onClick={addCustomProdItem}
+                className="flex items-center gap-1.5 rounded-full border border-white/10 bg-zinc-900 px-3 py-1.5 text-xs text-zinc-400 hover:border-nocturn/40 hover:bg-nocturn/10 hover:text-white transition-all active:scale-[0.97] min-h-[36px]"
+              >
+                <Plus className="h-3 w-3" />
+                Custom
+              </button>
+            </div>
+          )}
+
+          {draft.prodItems.length === 0 && (
+            <p className="text-[11px] text-muted-foreground/60">Tap a chip to add — ads, photographer, flyer designer, etc.</p>
+          )}
+        </div>
+
+        {/* Calculate */}
+        <Button
+          onClick={onCalculate}
+          disabled={calculating || !hasAnyExpense}
+          className="w-full bg-nocturn hover:bg-[#6B1FE7] text-white rounded-xl min-h-[44px] transition-all duration-200 active:scale-[0.98]"
+        >
+          {calculating ? <Loader2 className="h-4 w-4 animate-spin mr-2" /> : <TrendingUp className="h-4 w-4 mr-2" />}
+          Calculate Budget
+        </Button>
+
+        {/* Result */}
+        {result && (
+          <div className="rounded-xl bg-zinc-800/50 p-4 space-y-3 animate-fade-in">
+            <div className="flex items-center justify-between">
+              <span className="text-xs font-semibold text-zinc-400 uppercase tracking-wider">Budget Summary</span>
+              <span className="text-sm font-bold text-white">
+                {result.totalExpenses.toLocaleString()} {result.eventCurrency.toUpperCase()}
+              </span>
+            </div>
+
+            {/* Per-line-item breakdown with original currency visible */}
+            {result.resolvedItems.length > 0 && (
+              <div className="space-y-1 pt-1">
+                {result.resolvedItems.map((it, i) => {
+                  const converted = it.currency !== it.local_currency;
+                  return (
+                    <div key={i} className="flex items-center justify-between text-[11px] text-muted-foreground">
+                      <span>{it.label}</span>
+                      <span>
+                        {converted && (
+                          <span className="text-muted-foreground/50 mr-1">
+                            {it.amount.toLocaleString()} {it.currency.toUpperCase()} →
+                          </span>
+                        )}
+                        <span className="text-zinc-300">
+                          {Math.round(it.local_amount).toLocaleString()} {it.local_currency.toUpperCase()}
+                        </span>
+                      </span>
+                    </div>
+                  );
+                })}
+              </div>
+            )}
+
+            <p className="text-xs text-zinc-400 pt-1">
+              Break-even: <span className="text-white font-medium">{result.breakEven.ticketsNeeded} tickets</span> at {result.breakEven.atPrice} {result.eventCurrency.toUpperCase()}
+            </p>
+
+            <div className="space-y-1">
+              {result.scenarios.map((s, i) => (
+                <div key={i} className="flex items-center justify-between text-xs">
+                  <span className="text-muted-foreground">{s.label}</span>
+                  <span className={`font-medium ${s.profit >= 0 ? "text-green-400" : "text-red-400"}`}>
+                    {s.profit >= 0 ? "+" : ""}{s.profit.toLocaleString()} {result.eventCurrency.toUpperCase()}
+                  </span>
+                </div>
+              ))}
+            </div>
+
+            {result.suggestedTiers.length > 0 && tiers.length > 0 && (
+              <button
+                onClick={onApplySuggestedTiers}
+                className="text-xs text-nocturn hover:text-nocturn-light transition-colors"
+              >
+                Apply suggested tiers ({result.suggestedTiers.length} tiers)
+              </button>
+            )}
+          </div>
+        )}
+
+        {/* Market pricing sanity-check — sits next to the cost-plus suggestion
+            so operators don't anchor on expense-driven prices without seeing
+            what the local market is actually charging. */}
+        {result && venueCity && eventDate && result.suggestedTiers.length > 0 && (
+          <PricingInsight
+            city={venueCity}
+            date={eventDate}
+            venueCapacity={venueCapacity}
+            tiers={result.suggestedTiers.map(t => ({ name: t.name, price: t.price, capacity: t.capacity }))}
+          />
+        )}
+      </div>
+    </div>
+  );
+}
+
 // ─── Main Page ──────────────────────────────────────────────────────────────
 
 export default function NewEventPage() {
@@ -1214,7 +1778,7 @@ export default function NewEventPage() {
   const [step, setStep] = useState<WizardStep>("details");
   const [formData, setFormData] = useState<EventFormData>(DEFAULT_FORM);
   const [tiers, setTiers] = useState<TicketTier[]>([]);
-  const [budgetInput, setBudgetInput] = useState<Partial<BudgetInput>>({});
+  const [budgetDraft, setBudgetDraft] = useState<BudgetDraft>(() => defaultBudgetDraft());
   const [budgetResult, setBudgetResult] = useState<BudgetResult | null>(null);
   const [phase, setPhase] = useState<"wizard" | "creating" | "playbook" | "done">("wizard");
   const [error, setError] = useState<string | null>(null);
@@ -1257,28 +1821,41 @@ export default function NewEventPage() {
     return () => { cancelled = true; };
   }, []);
 
-  // Restore draft on mount
+  // Restore draft on mount. If no draft, fetch the collective's default
+  // currency so the budget step starts in the right unit (CAD for Toronto etc.)
+  // rather than USD.
   useEffect(() => {
     const draft = loadDraft();
     if (draft) {
       setStep(draft.step);
       setFormData(draft.formData);
       setTiers(draft.tiers);
-      setBudgetInput(draft.budgetInput);
+      setBudgetDraft(draft.budgetDraft);
       setBudgetResult(draft.budgetResult);
       setPhase(draft.phase === "creating" || draft.phase === "playbook" ? "wizard" : draft.phase);
+      setDraftLoaded(true);
+      return;
     }
-    setDraftLoaded(true);
+    // Fresh wizard — seed event currency from collective default.
+    getMyCollectiveDefaults()
+      .then((defaults) => {
+        const cc = defaults?.defaultCurrency ?? "usd";
+        setBudgetDraft((prev) => defaultBudgetDraft(cc) === prev ? prev : defaultBudgetDraft(cc));
+      })
+      .catch(() => {
+        // Stays on USD default, non-blocking.
+      })
+      .finally(() => setDraftLoaded(true));
   }, []);
 
   // Save draft on changes
   const saveDraftDebounced = useCallback(() => {
     const timer = setTimeout(() => {
       if (phase === "done" || phase === "playbook") return;
-      saveDraft({ version: DRAFT_VERSION, step, formData, tiers, budgetInput, budgetResult, phase });
+      saveDraft({ version: DRAFT_VERSION, step, formData, tiers, budgetDraft, budgetResult, phase });
     }, 500);
     return timer;
-  }, [step, formData, tiers, budgetInput, budgetResult, phase]);
+  }, [step, formData, tiers, budgetDraft, budgetResult, phase]);
 
   useEffect(() => {
     const timer = saveDraftDebounced();
@@ -1322,12 +1899,11 @@ export default function NewEventPage() {
     if (currentIdx > 0) goTo(activeSteps[currentIdx - 1]);
   }
 
-  // Total expenses from budget input (bar minimum is a threshold, not a direct expense — matches server logic)
-  const totalExpenses =
-    (budgetInput.talentFee || 0) +
-    (budgetInput.venueCost || 0) +
-    (budgetInput.deposit || 0) +
-    (budgetInput.otherExpenses || 0);
+  // Total expenses in the event's currency. Only reflects values *after* the
+  // Calculate Budget button has been tapped — before that, FX conversion hasn't
+  // happened and summing native-currency numbers would mix units.
+  // Bar minimum is a revenue threshold, not an expense (matches server logic).
+  const totalExpenses = budgetResult?.totalExpenses ?? 0;
 
   // Validation per step
   function canAdvance(): boolean {
@@ -1422,37 +1998,61 @@ export default function NewEventPage() {
     }
   }
 
-  // Calculate budget
+  // Calculate budget. Walks the BudgetDraft into flat ExpenseItems, sends to
+  // the server action which performs FX conversion and returns a resolved
+  // list + suggested tier prices.
   async function handleCalculateBudget() {
     setCalculatingBudget(true);
     setError(null);
     try {
       const input: BudgetInput = {
-        headlinerType: budgetInput.headlinerType || "none",
-        headlinerOrigin: budgetInput.headlinerOrigin,
-        talentFee: budgetInput.talentFee,
-        venueCost: budgetInput.venueCost,
-        barMinimum: budgetInput.barMinimum,
-        deposit: budgetInput.deposit,
-        otherExpenses: budgetInput.otherExpenses,
+        eventCurrency: budgetDraft.eventCurrency,
+        headlinerType: budgetDraft.headliner.type,
+        headlinerOrigin: budgetDraft.headliner.origin || undefined,
+        stayNights: budgetDraft.headliner.stayNights,
+        items: flattenBudget(budgetDraft),
+        barMinimum: budgetDraft.barMinimum || undefined,
         venueCity: formData.venueCity,
         venueCapacity: typeof formData.venueCapacity === "number" ? formData.venueCapacity : undefined,
         date: formData.date,
-        stayNights: budgetInput.stayNights,
       };
       const result = await calculateBudget(input);
       setBudgetResult(result);
 
       // Auto-update tiers if budget suggests them and user has no tiers yet
       if (result.suggestedTiers.length > 0 && tiers.length === 0) {
-        const firstTierPrice = tiers.length > 0 ? tiers[0].price : undefined;
-        const scaled = scaleBudgetTiers(result.suggestedTiers, firstTierPrice);
+        const scaled = scaleBudgetTiers(result.suggestedTiers, undefined);
         setTiers(scaled);
       }
     } catch {
       setError("Could not calculate budget — try again or skip this step.");
     } finally {
       setCalculatingBudget(false);
+    }
+  }
+
+  // Auto-fill the four travel rows (flights/hotel/transport/per-diem) from
+  // origin + venue city + nights. Server converts estimates to event currency.
+  async function handleSuggestTravel() {
+    if (!budgetDraft.headliner.origin || !formData.venueCity) return;
+    try {
+      const s = await suggestTravel({
+        headlinerOrigin: budgetDraft.headliner.origin,
+        venueCity: formData.venueCity,
+        stayNights: budgetDraft.headliner.stayNights,
+        eventCurrency: budgetDraft.eventCurrency,
+      });
+      setBudgetDraft(prev => ({
+        ...prev,
+        travel: {
+          flights:   { amount: s.flights,   currency: s.currency },
+          hotel:     { amount: s.hotel,     currency: s.currency },
+          transport: { amount: s.transport, currency: s.currency },
+          perDiem:   { amount: s.perDiem,   currency: s.currency },
+        },
+      }));
+    } catch {
+      // Silent: operator can still type numbers manually
     }
   }
 
@@ -1502,17 +2102,16 @@ export default function NewEventPage() {
         tiers: validTiers,
         eventMode: formData.isFree ? "rsvp" : "ticketed",
         isFree: formData.isFree,
-        // Persist the wizard's budget step. Without these, the P&L page
-        // shows $0 expenses and the edit form's Venue Financials section
-        // renders empty — even though the user already typed all of it.
-        // The wizard uses `deposit` as the field name for venue deposit;
-        // travel cost comes from the AI budget calculation, not user input.
-        talentFee: budgetInput.talentFee ?? null,
-        venueCost: budgetInput.venueCost ?? null,
-        venueDeposit: budgetInput.deposit ?? null,
-        barMinimum: budgetInput.barMinimum ?? null,
-        otherExpenses: budgetInput.otherExpenses ?? null,
-        travelCost: budgetResult?.travelEstimate?.total ?? null,
+        // Event currency = per-event override; createEvent falls back to the
+        // collective's default_currency if null.
+        currency: budgetDraft.eventCurrency,
+        // Persist the wizard's itemized budget so the P&L page and finance
+        // screens have the line-item breakdown with FX snapshots. Bar minimum
+        // is a threshold (revenue target), not an expense, so it rides along
+        // as a scalar.
+        barMinimum: budgetDraft.barMinimum || null,
+        venueCost: budgetDraft.venueRental || null,
+        expenseItems: budgetResult?.resolvedItems ?? null,
       });
 
       if (result.error) {
@@ -1825,7 +2424,7 @@ export default function NewEventPage() {
                   clearDraft();
                   setFormData(DEFAULT_FORM);
                   setTiers([]);
-                  setBudgetInput({});
+                  setBudgetDraft(defaultBudgetDraft(budgetDraft.eventCurrency));
                   setBudgetResult(null);
                   setStep("details");
                   setError(null);
@@ -2206,224 +2805,25 @@ export default function NewEventPage() {
 
         {/* ── STEP 4: Budget (Optional) ── */}
         {step === "budget" && (
-          <div className="space-y-5 animate-fade-in">
-            <div className="text-center space-y-1 pb-2">
-              <h2 className="text-lg font-bold font-heading bg-gradient-to-r from-[#7B2FF7] to-[#9D5CFF] bg-clip-text text-transparent">
-                Budget Planning
-              </h2>
-              <p className="text-sm text-muted-foreground">Optional — helps forecast profit</p>
-            </div>
-
-            {/* Skip button */}
-            <button
-              onClick={goNext}
-              className="w-full flex items-center justify-center gap-2 rounded-2xl border border-white/[0.06] bg-card p-4 text-sm text-zinc-400 hover:text-zinc-200 hover:border-nocturn/30 transition-all duration-200 active:scale-[0.98]"
-            >
-              <SkipForward className="h-4 w-4" />
-              Skip — I&apos;ll figure out costs later
-            </button>
-
-            <div className="rounded-2xl border border-white/[0.06] bg-card p-5 space-y-5">
-              {/* Headliner type */}
-              <div className="space-y-2">
-                <span className="flex items-center gap-1.5 text-sm font-medium text-zinc-300">
-                  <Music className="h-3.5 w-3.5 text-nocturn" />
-                  Headliner
-                </span>
-                <div className="grid grid-cols-3 gap-2" role="radiogroup" aria-label="Headliner type">
-                  {([
-                    { value: "international" as const, label: "International", icon: Plane },
-                    { value: "local" as const, label: "Local", icon: Music },
-                    { value: "none" as const, label: "No headliner", icon: Users },
-                  ]).map((opt) => (
-                    <button
-                      key={opt.value}
-                      role="radio"
-                      aria-checked={budgetInput.headlinerType === opt.value}
-                      onClick={() => setBudgetInput(prev => ({ ...prev, headlinerType: opt.value }))}
-                      className={`flex flex-col items-center gap-1.5 rounded-xl border p-3 text-center transition-all duration-200 active:scale-[0.98] min-h-[72px] ${
-                        budgetInput.headlinerType === opt.value
-                          ? "border-nocturn/40 bg-nocturn/5 text-white"
-                          : "border-white/[0.06] bg-zinc-900 text-zinc-400 hover:border-nocturn/30 hover:text-zinc-200"
-                      }`}
-                    >
-                      <opt.icon className="h-4 w-4" />
-                      <span className="text-xs font-medium">{opt.label}</span>
-                    </button>
-                  ))}
-                </div>
-              </div>
-
-              {/* Conditional headliner fields */}
-              {budgetInput.headlinerType === "international" && (
-                <div className="space-y-3 animate-fade-in">
-                  <FormField label="Flying from" icon={Plane}>
-                    <Input
-                      placeholder="London, UK"
-                      value={budgetInput.headlinerOrigin || ""}
-                      onChange={(e) => setBudgetInput(prev => ({ ...prev, headlinerOrigin: e.target.value }))}
-                      className="bg-zinc-900 border-white/10 rounded-xl min-h-[44px] focus:border-nocturn/50"
-                    />
-                  </FormField>
-                  <FormField label="Talent Fee" icon={DollarSign}>
-                    <Input
-                      type="number"
-                      placeholder="2000"
-                      value={budgetInput.talentFee || ""}
-                      onChange={(e) => setBudgetInput(prev => ({ ...prev, talentFee: parseInt(e.target.value) || 0 }))}
-                      className="bg-zinc-900 border-white/10 rounded-xl min-h-[44px] focus:border-nocturn/50"
-                    />
-                  </FormField>
-                  <FormField label="Stay (nights)" icon={Clock}>
-                    <Input
-                      type="number"
-                      placeholder="2"
-                      value={budgetInput.stayNights || ""}
-                      onChange={(e) => setBudgetInput(prev => ({ ...prev, stayNights: parseInt(e.target.value) || 0 }))}
-                      min={0}
-                      className="bg-zinc-900 border-white/10 rounded-xl min-h-[44px] focus:border-nocturn/50"
-                    />
-                  </FormField>
-                </div>
-              )}
-
-              {budgetInput.headlinerType === "local" && (
-                <div className="animate-fade-in">
-                  <FormField label="Talent Fee" icon={DollarSign}>
-                    <Input
-                      type="number"
-                      placeholder="500"
-                      value={budgetInput.talentFee || ""}
-                      onChange={(e) => setBudgetInput(prev => ({ ...prev, talentFee: parseInt(e.target.value) || 0 }))}
-                      className="bg-zinc-900 border-white/10 rounded-xl min-h-[44px] focus:border-nocturn/50"
-                    />
-                  </FormField>
-                </div>
-              )}
-
-              {/* Venue costs */}
-              <div className="space-y-3 border-t border-white/5 pt-4">
-                <span className="flex items-center gap-1.5 text-sm font-medium text-zinc-300">
-                  <DollarSign className="h-3.5 w-3.5 text-nocturn" />
-                  Venue Costs
-                </span>
-
-                <div className="grid grid-cols-2 gap-3">
-                  <div className="space-y-1">
-                    <label className="text-xs text-muted-foreground">Room Rental</label>
-                    <Input
-                      type="number"
-                      placeholder="0"
-                      value={budgetInput.venueCost || ""}
-                      onChange={(e) => setBudgetInput(prev => ({ ...prev, venueCost: parseInt(e.target.value) || 0 }))}
-                      className="bg-zinc-900 border-white/10 rounded-lg min-h-[40px] focus:border-nocturn/50"
-                    />
-                  </div>
-                  <div className="space-y-1">
-                    <label className="text-xs text-muted-foreground">Bar Minimum</label>
-                    <Input
-                      type="number"
-                      placeholder="0"
-                      value={budgetInput.barMinimum || ""}
-                      onChange={(e) => setBudgetInput(prev => ({ ...prev, barMinimum: parseInt(e.target.value) || 0 }))}
-                      className="bg-zinc-900 border-white/10 rounded-lg min-h-[40px] focus:border-nocturn/50"
-                    />
-                  </div>
-                  <div className="space-y-1">
-                    <label className="text-xs text-muted-foreground">Deposit</label>
-                    <Input
-                      type="number"
-                      placeholder="0"
-                      value={budgetInput.deposit || ""}
-                      onChange={(e) => setBudgetInput(prev => ({ ...prev, deposit: parseInt(e.target.value) || 0 }))}
-                      className="bg-zinc-900 border-white/10 rounded-lg min-h-[40px] focus:border-nocturn/50"
-                    />
-                  </div>
-                  <div className="space-y-1">
-                    <label className="text-xs text-muted-foreground">Other (sound, lights, etc.)</label>
-                    <Input
-                      type="number"
-                      placeholder="0"
-                      value={budgetInput.otherExpenses || ""}
-                      onChange={(e) => setBudgetInput(prev => ({ ...prev, otherExpenses: parseInt(e.target.value) || 0 }))}
-                      className="bg-zinc-900 border-white/10 rounded-lg min-h-[40px] focus:border-nocturn/50"
-                    />
-                  </div>
-                </div>
-              </div>
-
-              {/* Calculate button */}
-              <Button
-                onClick={handleCalculateBudget}
-                disabled={calculatingBudget || totalExpenses === 0}
-                className="w-full bg-nocturn hover:bg-[#6B1FE7] text-white rounded-xl min-h-[44px] transition-all duration-200 active:scale-[0.98]"
-              >
-                {calculatingBudget ? (
-                  <Loader2 className="h-4 w-4 animate-spin mr-2" />
-                ) : (
-                  <TrendingUp className="h-4 w-4 mr-2" />
-                )}
-                Calculate Budget
-              </Button>
-
-              {/* Budget result */}
-              {budgetResult && (
-                <div className="rounded-xl bg-zinc-800/50 p-4 space-y-3 animate-fade-in">
-                  <div className="flex items-center justify-between">
-                    <span className="text-xs font-semibold text-zinc-400 uppercase tracking-wider">Budget Summary</span>
-                    <span className="text-sm font-bold text-white">${budgetResult.totalExpenses.toLocaleString()}</span>
-                  </div>
-
-                  {budgetResult.travelEstimate && (
-                    <p className="text-xs text-zinc-400">
-                      Travel: ~${budgetResult.travelEstimate.total.toLocaleString()} ({budgetResult.travelEstimate.breakdown})
-                    </p>
-                  )}
-
-                  <p className="text-xs text-zinc-400">
-                    Break-even: <span className="text-white font-medium">{budgetResult.breakEven.ticketsNeeded} tickets</span> at ${budgetResult.breakEven.atPrice}
-                  </p>
-
-                  <div className="space-y-1">
-                    {budgetResult.scenarios.map((s, i) => (
-                      <div key={i} className="flex items-center justify-between text-xs">
-                        <span className="text-muted-foreground">{s.label}</span>
-                        <span className={`font-medium ${s.profit >= 0 ? "text-green-400" : "text-red-400"}`}>
-                          {s.profit >= 0 ? "+" : ""}${s.profit.toLocaleString()}
-                        </span>
-                      </div>
-                    ))}
-                  </div>
-
-                  {/* Apply suggested tiers button if user already has tiers */}
-                  {budgetResult.suggestedTiers.length > 0 && tiers.length > 0 && (
-                    <button
-                      onClick={() => {
-                        const firstPrice = tiers[0]?.price;
-                        const scaled = scaleBudgetTiers(budgetResult.suggestedTiers, firstPrice);
-                        setTiers(scaled);
-                      }}
-                      className="text-xs text-nocturn hover:text-nocturn-light transition-colors"
-                    >
-                      Apply suggested tiers ({budgetResult.suggestedTiers.length} tiers)
-                    </button>
-                  )}
-                </div>
-              )}
-
-              {/* Market pricing sanity-check — sits next to the cost-plus suggestion
-                  so operators don't anchor on expense-driven prices without seeing
-                  what the local market is actually charging. */}
-              {budgetResult && formData.venueCity && formData.date && budgetResult.suggestedTiers.length > 0 && (
-                <PricingInsight
-                  city={formData.venueCity}
-                  date={formData.date}
-                  venueCapacity={typeof formData.venueCapacity === "number" ? formData.venueCapacity : undefined}
-                  tiers={budgetResult.suggestedTiers.map(t => ({ name: t.name, price: t.price, capacity: t.capacity }))}
-                />
-              )}
-            </div>
-          </div>
+          <BudgetStep
+            draft={budgetDraft}
+            setDraft={setBudgetDraft}
+            result={budgetResult}
+            calculating={calculatingBudget}
+            venueCity={formData.venueCity}
+            eventDate={formData.date}
+            venueCapacity={typeof formData.venueCapacity === "number" ? formData.venueCapacity : undefined}
+            onSkip={goNext}
+            onCalculate={handleCalculateBudget}
+            onSuggestTravel={handleSuggestTravel}
+            tiers={tiers}
+            onApplySuggestedTiers={() => {
+              if (!budgetResult) return;
+              const firstPrice = tiers[0]?.price;
+              const scaled = scaleBudgetTiers(budgetResult.suggestedTiers, firstPrice);
+              setTiers(scaled);
+            }}
+          />
         )}
 
         {/* ── STEP 5: Review & Forecast ── */}

--- a/src/app/(dashboard)/dashboard/settings/page.tsx
+++ b/src/app/(dashboard)/dashboard/settings/page.tsx
@@ -14,7 +14,9 @@ import {
   CardTitle,
 } from "@/components/ui/card";
 import { Separator } from "@/components/ui/separator";
-import { Loader2, AlertCircle } from "lucide-react";
+import { Loader2, AlertCircle, Check } from "lucide-react";
+import { SUPPORTED_CURRENCIES } from "@/lib/currency";
+import { getMyCollectiveDefaults, updateCollectiveCurrency } from "@/app/actions/collective-settings";
 
 export default function SettingsPage() {
   const router = useRouter();
@@ -359,6 +361,9 @@ export default function SettingsPage() {
           </form>
         </CardContent>
       </Card>
+
+      {/* Default currency — set once, applies to every new event's budget P&L */}
+      <CurrencyCard />
       </div>
 
       <Separator />
@@ -401,5 +406,92 @@ export default function SettingsPage() {
         </CardContent>
       </Card>
     </div>
+  );
+}
+
+
+// ─── Currency Card ──────────────────────────────────────────────────────────
+// Sets the collective's default reporting currency for event budget P&L.
+// Per-event override still lives in the event-creation wizard; this is just
+// the starting value so Toronto collectives don't have to flip to CAD on
+// every new event.
+
+function CurrencyCard() {
+  const [currency, setCurrency] = useState<string>("usd");
+  const [loading, setLoading] = useState(true);
+  const [saving, setSaving] = useState(false);
+  const [saved, setSaved] = useState(false);
+  const [err, setErr] = useState<string | null>(null);
+
+  useEffect(() => {
+    getMyCollectiveDefaults()
+      .then(d => { if (d) setCurrency(d.defaultCurrency); })
+      .catch(() => { /* keep USD default */ })
+      .finally(() => setLoading(false));
+  }, []);
+
+  async function onSave() {
+    setSaving(true);
+    setErr(null);
+    setSaved(false);
+    const res = await updateCollectiveCurrency({ currency });
+    if (res.error) setErr(res.error);
+    else {
+      setSaved(true);
+      setTimeout(() => setSaved(false), 2500);
+    }
+    setSaving(false);
+  }
+
+  return (
+    <Card>
+      <CardHeader>
+        <CardTitle>Default currency</CardTitle>
+        <CardDescription>
+          The currency your event budgets report in. Each event can still override this
+          in the Budget step — handy when you throw in a different country.
+        </CardDescription>
+      </CardHeader>
+      <CardContent className="space-y-4">
+        <div className="space-y-2 max-w-sm">
+          <Label htmlFor="defaultCurrency">Currency</Label>
+          <select
+            id="defaultCurrency"
+            value={currency}
+            onChange={(e) => setCurrency(e.target.value)}
+            disabled={loading || saving}
+            className="w-full bg-zinc-900 border border-white/10 rounded-xl px-3 text-sm text-white focus:border-nocturn/50 focus:outline-none min-h-[44px] disabled:opacity-50"
+          >
+            {SUPPORTED_CURRENCIES.map(c => (
+              <option key={c.code} value={c.code}>{c.label}</option>
+            ))}
+          </select>
+        </div>
+
+        {err && (
+          <p className="text-sm text-red-500 flex items-center gap-1.5">
+            <AlertCircle className="h-4 w-4" />
+            {err}
+          </p>
+        )}
+
+        <div className="flex items-center gap-3">
+          <Button
+            onClick={onSave}
+            disabled={loading || saving}
+            className="bg-nocturn hover:bg-nocturn-light min-h-[44px] transition-all duration-200 active:scale-[0.98] disabled:active:scale-100"
+          >
+            {saving && <Loader2 className="mr-2 h-4 w-4 animate-spin" />}
+            {saving ? "Saving..." : "Save currency"}
+          </Button>
+          {saved && (
+            <span className="text-sm text-emerald-500 flex items-center gap-1.5 animate-fade-in">
+              <Check className="h-4 w-4" />
+              Saved
+            </span>
+          )}
+        </div>
+      </CardContent>
+    </Card>
   );
 }

--- a/src/app/actions/budget-planner.ts
+++ b/src/app/actions/budget-planner.ts
@@ -1,251 +1,253 @@
 "use server";
 
 import { createClient as createServerClient } from "@/lib/supabase/server";
+import { convertBetween } from "@/lib/currency";
 
-export interface BudgetInput {
-  headlinerType: "local" | "international" | "none";
-  headlinerOrigin?: string; // e.g. "London, UK" or "New York"
-  talentFee?: number;
-  venueCost?: number; // room rental
-  barMinimum?: number;
-  deposit?: number;
-  otherExpenses?: number; // sound, lights, security, promo
-  venueCity?: string;
-  venueCapacity?: number;
-  date?: string;
-  stayNights?: number; // how many nights the artist is staying
+// ─── Expense categories ─────────────────────────────────────────────────────
+// Organizers think about expenses in buckets, not a flat list. These categories
+// drive the UI (chip-add for production/marketing) and the suggested-expense
+// auto-fill for international headliners (flights/hotel/transport/per_diem).
+export type ExpenseCategory =
+  | "talent"
+  | "flights"
+  | "hotel"
+  | "transport"
+  | "per_diem"
+  | "venue_rental"
+  | "bar_minimum"
+  | "deposit"
+  | "ads"
+  | "graphic_design"
+  | "photo"
+  | "video"
+  | "other";
+
+export interface ExpenseItem {
+  category: ExpenseCategory;
+  label: string;      // human-readable, e.g. "Talent fee" or "Flyer designer"
+  amount: number;     // in the item's native currency, whole units (not cents)
+  currency: string;   // ISO 4217 lowercase, e.g. "usd"
 }
 
-export interface TravelEstimate {
+/**
+ * Snapshot of an ExpenseItem after server-side FX conversion into the event's
+ * reporting currency. The `local_*` fields are what feed the P&L / break-even.
+ */
+export interface ExpenseItemResolved extends ExpenseItem {
+  local_amount: number; // converted to event_currency at entry time
+  local_currency: string;
+  fx_rate: number;      // rate from `currency` → `local_currency`
+  fx_locked_at: string; // ISO 8601
+}
+
+export interface BudgetInput {
+  // Event-level currency. All totals and break-even math use this unit.
+  // Caller passes this in; the client resolves it from event override →
+  // collective default → "usd".
+  eventCurrency: string;
+
+  // Headliner context (drives travel auto-suggest)
+  headlinerType: "local" | "international" | "none";
+  headlinerOrigin?: string;
+  stayNights?: number;
+
+  // Itemized expenses in their native currencies.
+  items: ExpenseItem[];
+
+  // Bar minimum is a revenue threshold, not an expense. Kept separate so the
+  // planner can flag deposit-at-risk without double-counting.
+  barMinimum?: number;
+
+  // Used to cap break-even math and auto-suggest flights/hotel per city.
+  venueCity?: string;
+  venueCapacity?: number;
+
+  date?: string;
+}
+
+export interface TravelSuggestion {
   flights: number;
   hotel: number;
   transport: number;
   perDiem: number;
-  total: number;
+  currency: string; // the suggestion is always denominated in the event currency
   breakdown: string;
 }
 
 export interface BudgetResult {
-  totalExpenses: number;
-  travelEstimate: TravelEstimate | null;
+  eventCurrency: string;
+  totalExpenses: number;           // grand total in eventCurrency
+  resolvedItems: ExpenseItemResolved[];
   suggestedTiers: Array<{
     name: string;
     price: number;
     capacity: number;
     reasoning: string;
   }>;
-  breakEven: {
-    ticketsNeeded: number;
-    atPrice: number;
-  };
-  scenarios: Array<{
-    label: string;
-    soldPct: number;
-    revenue: number;
-    profit: number;
-  }>;
+  breakEven: { ticketsNeeded: number; atPrice: number };
+  scenarios: Array<{ label: string; soldPct: number; revenue: number; profit: number }>;
   summary: string;
 }
 
-// Rough flight cost estimates by region
-function estimateFlightCost(origin: string): number {
+// ─── Travel estimates (unchanged logic, denominated in USD then converted) ──
+function estimateFlightCostUSD(origin: string): number {
   const lower = origin.toLowerCase();
-
-  // North America domestic
-  if (["new york", "nyc", "la", "los angeles", "miami", "chicago", "detroit", "atlanta", "montreal", "vancouver"].some(c => lower.includes(c))) {
-    return 350;
-  }
-  // US/Canada general
-  if (["us", "usa", "united states", "canada"].some(c => lower.includes(c))) {
-    return 400;
-  }
-  // UK/Europe
-  if (["uk", "london", "berlin", "amsterdam", "paris", "ibiza", "spain", "france", "germany", "netherlands", "europe", "italy", "barcelona"].some(c => lower.includes(c))) {
-    return 900;
-  }
-  // Australia/Asia
-  if (["australia", "sydney", "melbourne", "japan", "tokyo", "korea", "seoul", "asia"].some(c => lower.includes(c))) {
-    return 1400;
-  }
-  // South America
-  if (["brazil", "colombia", "argentina", "mexico", "south america", "latin america"].some(c => lower.includes(c))) {
-    return 700;
-  }
-  // Africa
-  if (["south africa", "nigeria", "africa"].some(c => lower.includes(c))) {
-    return 1200;
-  }
-
-  // Default — assume international
+  if (["new york", "nyc", "la", "los angeles", "miami", "chicago", "detroit", "atlanta", "montreal", "vancouver"].some(c => lower.includes(c))) return 350;
+  if (["us", "usa", "united states", "canada"].some(c => lower.includes(c))) return 400;
+  if (["uk", "london", "berlin", "amsterdam", "paris", "ibiza", "spain", "france", "germany", "netherlands", "europe", "italy", "barcelona"].some(c => lower.includes(c))) return 900;
+  if (["australia", "sydney", "melbourne", "japan", "tokyo", "korea", "seoul", "asia"].some(c => lower.includes(c))) return 1400;
+  if (["brazil", "colombia", "argentina", "mexico", "south america", "latin america"].some(c => lower.includes(c))) return 700;
+  if (["south africa", "nigeria", "africa"].some(c => lower.includes(c))) return 1200;
   return 800;
 }
 
-function estimateHotelPerNight(city: string): number {
+function estimateHotelPerNightUSD(city: string): number {
   const lower = city.toLowerCase();
-  if (["toronto", "new york", "nyc", "la", "los angeles", "miami", "london", "paris"].some(c => lower.includes(c))) {
-    return 200; // premium city
-  }
-  if (["montreal", "vancouver", "chicago", "berlin", "amsterdam"].some(c => lower.includes(c))) {
-    return 160;
-  }
-  return 130; // default
+  if (["toronto", "new york", "nyc", "la", "los angeles", "miami", "london", "paris"].some(c => lower.includes(c))) return 200;
+  if (["montreal", "vancouver", "chicago", "berlin", "amsterdam"].some(c => lower.includes(c))) return 160;
+  return 130;
 }
 
+/**
+ * Pure travel-suggestion helper: estimate flights/hotel/transport/per-diem in
+ * USD, then convert to the event's currency at today's rate. Caller decides
+ * whether to populate these as ExpenseItems (client auto-fill) or display as
+ * a non-binding hint.
+ */
+export async function suggestTravel(input: {
+  headlinerOrigin: string;
+  venueCity: string;
+  stayNights?: number;
+  eventCurrency: string;
+}): Promise<TravelSuggestion> {
+  const nights = input.stayNights ?? 2;
+  const flightsUSD = estimateFlightCostUSD(input.headlinerOrigin);
+  const hotelPerNightUSD = estimateHotelPerNightUSD(input.venueCity);
+  const hotelUSD = hotelPerNightUSD * nights;
+  const transportUSD = 150;
+  const perDiemUSD = 75 * nights;
+
+  const target = input.eventCurrency.toLowerCase();
+  const [flights, hotel, transport, perDiem] = await Promise.all([
+    convertBetween(flightsUSD, "usd", target),
+    convertBetween(hotelUSD, "usd", target),
+    convertBetween(transportUSD, "usd", target),
+    convertBetween(perDiemUSD, "usd", target),
+  ]);
+
+  return {
+    flights: Math.round(flights.amount),
+    hotel: Math.round(hotel.amount),
+    transport: Math.round(transport.amount),
+    perDiem: Math.round(perDiem.amount),
+    currency: target,
+    breakdown: `Flights from ${input.headlinerOrigin} · Hotel (${nights} nights × ~$${hotelPerNightUSD} USD/night) · Transport · Per diem (${nights} nights × $75 USD/day) — converted to ${target.toUpperCase()}`,
+  };
+}
+
+// ─── Main entry point ───────────────────────────────────────────────────────
 export async function calculateBudget(input: BudgetInput): Promise<BudgetResult> {
-  const emptyResult: BudgetResult = { totalExpenses: 0, travelEstimate: null, suggestedTiers: [], breakEven: { ticketsNeeded: 0, atPrice: 0 }, scenarios: [], summary: "Something went wrong" };
+  const eventCurrency = (input.eventCurrency || "usd").toLowerCase();
+  const emptyResult: BudgetResult = {
+    eventCurrency,
+    totalExpenses: 0,
+    resolvedItems: [],
+    suggestedTiers: [],
+    breakEven: { ticketsNeeded: 0, atPrice: 0 },
+    scenarios: [],
+    summary: "Something went wrong",
+  };
+
   try {
     const supabase = await createServerClient();
     const { data: { user } } = await supabase.auth.getUser();
     if (!user) return { ...emptyResult, summary: "Not authenticated" };
 
-    // Input validation
     if (input.venueCapacity !== undefined && (input.venueCapacity < 1 || input.venueCapacity > 100000)) {
       return { ...emptyResult, summary: "Venue capacity must be between 1 and 100,000" };
     }
-    if (input.talentFee !== undefined && input.talentFee < 0) {
-      return { ...emptyResult, summary: "Talent fee cannot be negative" };
-    }
-    if (input.venueCost !== undefined && input.venueCost < 0) {
-      return { ...emptyResult, summary: "Venue cost cannot be negative" };
-    }
 
-    let travelEstimate: TravelEstimate | null = null;
-
-    if (input.headlinerType === "international" && input.headlinerOrigin) {
-      const flights = estimateFlightCost(input.headlinerOrigin);
-      const nights = input.stayNights ?? 2;
-      const hotelPerNight = estimateHotelPerNight(input.venueCity ?? "toronto");
-      const hotel = hotelPerNight * nights;
-      const transport = 150; // airport transfers + local
-      const perDiem = 75 * nights; // meals etc
-
-      travelEstimate = {
-        flights,
-        hotel,
-        transport,
-        perDiem,
-        total: flights + hotel + transport + perDiem,
-        breakdown: `Flights from ${input.headlinerOrigin}: ~$${flights} • Hotel (${nights} nights × $${hotelPerNight}): ~$${hotel} • Transport: ~$${transport} • Per diem: ~$${perDiem}`,
-      };
+    // Validate amounts upfront so a malformed row doesn't get silently summed as 0.
+    for (const it of input.items) {
+      if (!Number.isFinite(it.amount) || it.amount < 0 || it.amount > 10_000_000) {
+        return { ...emptyResult, summary: `Invalid amount on "${it.label}"` };
+      }
+      if (!/^[a-z]{3}$/.test(it.currency.toLowerCase())) {
+        return { ...emptyResult, summary: `Invalid currency code "${it.currency}"` };
+      }
     }
 
-    const talentFee = input.talentFee ?? 0;
-    const venueCost = input.venueCost ?? 0;
-    const barMinimum = input.barMinimum ?? 0;
-    const deposit = input.deposit ?? 0;
-    const otherExpenses = input.otherExpenses ?? 0;
-    const travelCost = travelEstimate?.total ?? 0;
+    // Convert every line to the event's currency in parallel. One snapshot
+    // timestamp for the whole calculation so the P&L math is internally
+    // consistent even if rates update mid-flight.
+    const fxLockedAt = new Date().toISOString();
+    const resolvedItems: ExpenseItemResolved[] = await Promise.all(
+      input.items.map(async (it) => {
+        const { amount: local_amount, rate } = await convertBetween(
+          it.amount,
+          it.currency,
+          eventCurrency,
+        );
+        return {
+          ...it,
+          currency: it.currency.toLowerCase(),
+          local_amount,
+          local_currency: eventCurrency,
+          fx_rate: rate,
+          fx_locked_at: fxLockedAt,
+        };
+      }),
+    );
 
-    const totalExpenses = talentFee + venueCost + deposit + otherExpenses + travelCost;
-    // Bar minimum is a threshold, not a direct expense (but deposit risk if not met)
-
+    const totalExpenses = resolvedItems.reduce((s, it) => s + it.local_amount, 0);
     const capacity = input.venueCapacity ?? 200;
 
-    // Calculate break-even price.
-    // Organizer keeps 100% of ticket price — buyer pays Nocturn's 7%+$0.50 service fee
-    // on top at checkout, and Nocturn absorbs Stripe processing. So no fee gross-up here.
-    // Target 75% sell-through for safety.
+    // Organizer keeps 100% of ticket price — buyer pays Nocturn's 7%+$0.50
+    // at checkout and Nocturn absorbs Stripe. No fee gross-up here.
     const targetTickets = Math.round(capacity * 0.75);
-    const breakEvenPrice = targetTickets > 0
-      ? Math.ceil(totalExpenses / targetTickets)
-      : 0;
+    const breakEvenPrice = targetTickets > 0 ? Math.ceil(totalExpenses / targetTickets) : 0;
 
-    // Suggest tiers
-    // Round all marketed prices UP to the nearest $5 — flat numbers like
-    // $25/$30/$40 are easier to promote on flyers and IG stories than
-    // odd values like $23 or $37. Break-even stays raw because it's the
-    // underlying math, not a price we ever show on a flyer.
+    // Round marketed prices up to the nearest $5 (flat numbers promote better).
     const roundUpToFive = (n: number) => Math.ceil(n / 5) * 5;
-
-    const gaPriceRaw = Math.max(breakEvenPrice, 15); // minimum $15
+    const gaPriceRaw = Math.max(breakEvenPrice, 15);
     const tier1Price = roundUpToFive(gaPriceRaw);
-    // Compute bumps off the rounded tier1 so the gaps stay clean ($5/$10).
     const tier2Price = roundUpToFive(tier1Price * 1.25);
     const tier3Price = roundUpToFive(tier1Price * 1.5);
-    // Early bird: nearest $5 to 0.75x tier1, but always strictly below
-    // tier1 (otherwise the discount vanishes on small numbers like $15).
     const earlyBirdRounded = Math.round((tier1Price * 0.75) / 5) * 5;
     const earlyBirdPrice = Math.max(Math.min(earlyBirdRounded, tier1Price - 5), 5);
 
-    const suggestedTiers: Array<{ name: string; price: number; capacity: number; reasoning: string }> = [];
+    const suggestedTiers = [
+      { name: "Early Bird",  price: earlyBirdPrice, capacity: Math.round(capacity * 0.15), reasoning: "Limited release at a discount to build early momentum and social proof" },
+      { name: "Tier 1",      price: tier1Price,     capacity: Math.round(capacity * 0.35), reasoning: `Main release — priced to cover costs at 75% sell-through (${breakEvenPrice} ${eventCurrency.toUpperCase()} break-even)` },
+      { name: "Tier 2",      price: tier2Price,     capacity: Math.round(capacity * 0.30), reasoning: "Price bump for later buyers — 25% above Tier 1" },
+      { name: "Tier 3",      price: tier3Price,     capacity: Math.round(capacity * 0.20), reasoning: "Final release / door price — 50% above Tier 1 for maximum margin" },
+    ];
 
-    // Tiered pricing: Early Bird → Tier 1 → Tier 2 → Tier 3
-    // Early Bird gets people in early (limited, cheapest)
-    // Tier 1 is the main price
-    // Tier 2 is a slight bump for later buyers
-    // Tier 3 is door price / last minute
-
-    suggestedTiers.push({
-      name: "Early Bird",
-      price: earlyBirdPrice,
-      capacity: Math.round(capacity * 0.15),
-      reasoning: `Limited release at a discount to build early momentum and social proof`,
-    });
-
-    suggestedTiers.push({
-      name: "Tier 1",
-      price: tier1Price,
-      capacity: Math.round(capacity * 0.35),
-      reasoning: `Main release — priced to cover costs at 75% sell-through ($${breakEvenPrice} break-even)`,
-    });
-
-    suggestedTiers.push({
-      name: "Tier 2",
-      price: tier2Price,
-      capacity: Math.round(capacity * 0.30),
-      reasoning: `Price bump for later buyers — 25% above Tier 1`,
-    });
-
-    suggestedTiers.push({
-      name: "Tier 3",
-      price: tier3Price,
-      capacity: Math.round(capacity * 0.20),
-      reasoning: `Final release / door price — 50% above Tier 1 for maximum margin`,
-    });
-
-    // Calculate scenarios using suggested tiers
-    function calcScenario(soldPct: number) {
+    const calcScenario = (soldPct: number) => {
       let revenue = 0;
-      let ticketsSold = 0;
-      for (const tier of suggestedTiers) {
-        const sold = Math.round(tier.capacity * soldPct);
-        ticketsSold += sold;
-        revenue += sold * tier.price;
-      }
-      // Fees are paid by buyer, so organizer keeps full ticket price
-      // But we subtract expenses
-      const profit = revenue - totalExpenses;
-      return { ticketsSold, revenue, profit };
-    }
-
+      for (const tier of suggestedTiers) revenue += Math.round(tier.capacity * soldPct) * tier.price;
+      return { revenue, profit: revenue - totalExpenses };
+    };
     const scenarios = [
-      { label: "50% sold", soldPct: 0.5, emoji: "😐" },
-      { label: "75% sold", soldPct: 0.75, emoji: "🔥" },
-      { label: "Sell-out", soldPct: 1.0, emoji: "🚀" },
-    ].map(s => {
-      const calc = calcScenario(s.soldPct);
-      return {
-        label: s.label,
-        soldPct: s.soldPct,
-        revenue: calc.revenue,
-        profit: calc.profit,
-      };
-    });
+      { label: "50% sold", soldPct: 0.5 },
+      { label: "75% sold", soldPct: 0.75 },
+      { label: "Sell-out", soldPct: 1.0 },
+    ].map(s => ({ ...s, ...calcScenario(s.soldPct) }));
 
-    // Generate summary
+    const barMinimum = input.barMinimum ?? 0;
+    const deposit = resolvedItems.find(i => i.category === "deposit")?.local_amount ?? 0;
+
     const profitAt75 = scenarios[1].profit;
     const summary = profitAt75 >= 0
-      ? `Total expenses: $${totalExpenses.toLocaleString()}. At 75% capacity you'd make $${profitAt75.toLocaleString()} profit. ${barMinimum > 0 ? `Bar minimum of $${barMinimum.toLocaleString()} — if you don't hit it, you lose your $${deposit.toLocaleString()} deposit.` : ""}`
-      : `Total expenses: $${totalExpenses.toLocaleString()}. You'd need to sell ${Math.ceil(capacity * 0.75)} tickets at $${tier1Price} to break even. ${barMinimum > 0 ? `Bar minimum of $${barMinimum.toLocaleString()} adds risk.` : ""} Consider reducing costs or raising ticket prices.`;
+      ? `Total expenses: ${totalExpenses.toLocaleString()} ${eventCurrency.toUpperCase()}. At 75% capacity you'd make ${profitAt75.toLocaleString()} ${eventCurrency.toUpperCase()} profit.${barMinimum > 0 ? ` Bar minimum of ${barMinimum.toLocaleString()}${deposit > 0 ? ` — if you don't hit it, you lose your ${deposit.toLocaleString()} deposit.` : "."}` : ""}`
+      : `Total expenses: ${totalExpenses.toLocaleString()} ${eventCurrency.toUpperCase()}. You'd need to sell ${Math.ceil(capacity * 0.75)} tickets at ${tier1Price} ${eventCurrency.toUpperCase()} to break even.${barMinimum > 0 ? ` Bar minimum of ${barMinimum.toLocaleString()} adds risk.` : ""} Consider reducing costs or raising ticket prices.`;
 
     return {
+      eventCurrency,
       totalExpenses,
-      travelEstimate,
+      resolvedItems,
       suggestedTiers,
-      breakEven: {
-        ticketsNeeded: targetTickets,
-        atPrice: breakEvenPrice,
-      },
+      breakEven: { ticketsNeeded: targetTickets, atPrice: breakEvenPrice },
       scenarios,
       summary,
     };

--- a/src/app/actions/collective-settings.ts
+++ b/src/app/actions/collective-settings.ts
@@ -1,0 +1,95 @@
+"use server";
+
+import { createClient as createServerClient } from "@/lib/supabase/server";
+import { createAdminClient } from "@/lib/supabase/config";
+import { SUPPORTED_CURRENCIES } from "@/lib/currency";
+import { revalidatePath } from "next/cache";
+
+export interface CollectiveDefaults {
+  collectiveId: string;
+  defaultCurrency: string;
+}
+
+/**
+ * Return the signed-in user's first collective's default currency + ID.
+ * Used by the event-creation wizard to pre-select the Budget step's event
+ * currency picker. Falls back to { defaultCurrency: "usd" } on any failure
+ * since a non-critical preference shouldn't block the wizard.
+ */
+export async function getMyCollectiveDefaults(): Promise<CollectiveDefaults | null> {
+  try {
+    const supabase = await createServerClient();
+    const { data: { user } } = await supabase.auth.getUser();
+    if (!user) return null;
+
+    const admin = createAdminClient();
+    const { data: membership } = await admin
+      .from("collective_members")
+      .select("collective_id")
+      .eq("user_id", user.id)
+      .is("deleted_at", null)
+      .limit(1)
+      .maybeSingle();
+    if (!membership) return null;
+
+    const { data: collective } = await admin
+      .from("collectives")
+      .select("id, default_currency")
+      .eq("id", membership.collective_id)
+      .maybeSingle();
+    if (!collective) return null;
+
+    return {
+      collectiveId: collective.id,
+      defaultCurrency: (collective.default_currency ?? "usd").toLowerCase(),
+    };
+  } catch (err) {
+    console.error("[getMyCollectiveDefaults]", err);
+    return null;
+  }
+}
+
+/**
+ * Update the collective's default_currency. Caller must be a member.
+ */
+export async function updateCollectiveCurrency(input: { currency: string }): Promise<{ error: string | null }> {
+  try {
+    const currency = input.currency.toLowerCase();
+    if (!/^[a-z]{3}$/.test(currency)) {
+      return { error: "Currency must be a 3-letter ISO code (e.g. usd, cad, eur)." };
+    }
+    if (!SUPPORTED_CURRENCIES.some(c => c.code === currency)) {
+      return { error: "Unsupported currency." };
+    }
+
+    const supabase = await createServerClient();
+    const { data: { user } } = await supabase.auth.getUser();
+    if (!user) return { error: "Not authenticated" };
+
+    const admin = createAdminClient();
+    const { data: membership } = await admin
+      .from("collective_members")
+      .select("collective_id")
+      .eq("user_id", user.id)
+      .is("deleted_at", null)
+      .limit(1)
+      .maybeSingle();
+    if (!membership) return { error: "No collective found" };
+
+    const { error: updateErr } = await admin
+      .from("collectives")
+      .update({ default_currency: currency })
+      .eq("id", membership.collective_id);
+
+    if (updateErr) {
+      console.error("[updateCollectiveCurrency] update failed:", updateErr.message);
+      return { error: "Failed to update currency" };
+    }
+
+    revalidatePath("/dashboard/settings");
+    return { error: null };
+  } catch (err) {
+    console.error("[updateCollectiveCurrency]", err);
+    return { error: "Something went wrong" };
+  }
+}

--- a/src/app/actions/events.ts
+++ b/src/app/actions/events.ts
@@ -7,6 +7,7 @@ import { generateAutoSettlement } from "./auto-settlement";
 import { getStripe } from "@/lib/stripe";
 import { DEFAULT_TIMEZONE } from "@/lib/utils";
 import { rateLimitStrict } from "@/lib/rate-limit";
+import type { Database } from "@/lib/supabase/database.types";
 
 function slugify(text: string): string {
   return text
@@ -46,6 +47,23 @@ interface CreateEventInput {
   // Talent travel (flights/hotel/transport/per diem). May be a server-computed
   // estimate from calculateBudget rather than a user input.
   travelCost?: number | null;
+  // ── Multi-currency budget (v2) ──
+  // `currency` is the event's reporting currency (per-event override; when
+  // omitted the event inherits the collective's default_currency).
+  currency?: string | null;
+  // When the wizard's Budget step produces resolved line items via
+  // calculateBudget(), they land here. Each row writes to the `expenses`
+  // table with FX snapshot stashed in metadata for later settlement math.
+  expenseItems?: Array<{
+    category: string;
+    label: string;
+    amount: number;        // original amount in the row's native currency
+    currency: string;      // ISO 4217 lowercase
+    local_amount: number;  // amount in the event's reporting currency
+    local_currency: string;
+    fx_rate: number;
+    fx_locked_at: string;
+  }> | null;
 }
 
 interface UpdateEventInput {
@@ -323,6 +341,14 @@ export async function createEvent(input: CreateEventInput) {
   const otherExpensesClean = safeMoney(input.otherExpenses);
   const travelCostClean = safeMoney(input.travelCost);
 
+  // ── v2 multi-currency budget ──
+  // Sanitize the event-level currency override. NULL means "inherit from
+  // collective.default_currency" (handled at read time, not write time).
+  const eventCurrencyClean =
+    typeof input.currency === "string" && /^[a-z]{3}$/.test(input.currency.toLowerCase())
+      ? input.currency.toLowerCase()
+      : null;
+
   // Create event
   const { data: event, error: eventError } = await admin
     .from("events")
@@ -346,6 +372,7 @@ export async function createEvent(input: CreateEventInput) {
       venue_deposit: venueDepositClean,
       bar_minimum: barMinimumClean,
       estimated_bar_revenue: estimatedBarRevenueClean,
+      ...(eventCurrencyClean ? { currency: eventCurrencyClean } : {}),
       metadata: {
         timezone: tz,
         ...(dressCode ? { dress_code: dressCode } : {}),
@@ -387,44 +414,61 @@ export async function createEvent(input: CreateEventInput) {
   }
 
   // Persist budget-step line items as expense rows so the P&L reads them
-  // back without asking the user to re-enter every cost. These mirror the
-  // buckets the wizard's budget step collects. Failure here is non-fatal
-  // — the event itself is already saved and the user can re-add expenses
-  // manually on the financials page.
-  const budgetExpenseRows: Array<{
-    event_id: string;
-    collective_id: string;
-    description: string;
-    category: string;
-    amount: number;
-  }> = [];
-  if (talentFeeClean && talentFeeClean > 0) {
-    budgetExpenseRows.push({
-      event_id: event.id,
-      collective_id: collectiveId,
-      description: "Talent fee",
-      category: "artist",
-      amount: talentFeeClean,
-    });
+  // back without asking the user to re-enter every cost. Failure here is
+  // non-fatal — the event itself is already saved and the user can re-add
+  // expenses manually on the financials page.
+  //
+  // v2 multi-currency path: if `expenseItems` was provided, write each
+  // resolved row (post-FX) and stash the original amount/currency/rate in
+  // metadata for audit. Legacy callers that pass flat talentFee/otherExpenses/
+  // travelCost still work via the fallback branch below.
+  type BudgetExpenseRow = Database["public"]["Tables"]["expenses"]["Insert"];
+  const budgetExpenseRows: BudgetExpenseRow[] = [];
+
+  if (input.expenseItems && input.expenseItems.length > 0) {
+    for (const it of input.expenseItems) {
+      const localAmt = safeMoney(it.local_amount);
+      if (!localAmt || localAmt <= 0) continue;
+      budgetExpenseRows.push({
+        event_id: event.id,
+        collective_id: collectiveId,
+        description: it.label.slice(0, 200),
+        category: it.category,
+        amount: localAmt, // stored in the event's reporting currency
+        metadata: {
+          original_amount: it.amount,
+          original_currency: it.currency,
+          local_currency: it.local_currency,
+          fx_rate: it.fx_rate,
+          fx_locked_at: it.fx_locked_at,
+        },
+      });
+    }
+  } else {
+    // Legacy path — scalar fields only. Kept for backward compat with any
+    // caller that hasn't migrated to itemized input yet.
+    if (talentFeeClean && talentFeeClean > 0) {
+      budgetExpenseRows.push({
+        event_id: event.id, collective_id: collectiveId,
+        description: "Talent fee", category: "artist", amount: talentFeeClean,
+      });
+    }
+    if (travelCostClean && travelCostClean > 0) {
+      budgetExpenseRows.push({
+        event_id: event.id, collective_id: collectiveId,
+        description: "Talent travel (flights, hotel, transport)",
+        category: "transportation", amount: travelCostClean,
+      });
+    }
+    if (otherExpensesClean && otherExpensesClean > 0) {
+      budgetExpenseRows.push({
+        event_id: event.id, collective_id: collectiveId,
+        description: "Other expenses (sound, lights, security, promo)",
+        category: "other", amount: otherExpensesClean,
+      });
+    }
   }
-  if (travelCostClean && travelCostClean > 0) {
-    budgetExpenseRows.push({
-      event_id: event.id,
-      collective_id: collectiveId,
-      description: "Talent travel (flights, hotel, transport)",
-      category: "transportation",
-      amount: travelCostClean,
-    });
-  }
-  if (otherExpensesClean && otherExpensesClean > 0) {
-    budgetExpenseRows.push({
-      event_id: event.id,
-      collective_id: collectiveId,
-      description: "Other expenses (sound, lights, security, promo)",
-      category: "other",
-      amount: otherExpensesClean,
-    });
-  }
+
   if (budgetExpenseRows.length > 0) {
     const { error: expErr } = await admin.from("expenses").insert(budgetExpenseRows);
     if (expErr) {

--- a/src/lib/currency.ts
+++ b/src/lib/currency.ts
@@ -178,3 +178,96 @@ export function formatLocalAmount(amount: number, currency: string): string {
 
   return `${symbol}${(amount / 100).toFixed(2)}`;
 }
+
+// ─── Multi-currency budget support ──────────────────────────────────────────
+// Used by the event budget intake: operators enter headliner fees in the
+// currency they actually pay (USD for international DJs, local for venues),
+// and the P&L converts everything to the event's currency at entry time.
+
+/**
+ * Convert a dollar amount (whole units, not cents) from one currency to
+ * another, using USD as the cross-rate pivot.
+ *
+ * Returns the converted amount plus the effective rate so callers can
+ * snapshot the rate for audit/settlement consistency.
+ *
+ * Falls back to { amount, rate: 1 } if either currency is unsupported —
+ * callers should treat an explicit rate of 1 with mismatched currencies
+ * as a "rate unavailable, check network" signal if needed.
+ */
+export async function convertBetween(
+  amount: number,
+  fromCurrency: string,
+  toCurrency: string,
+): Promise<{ amount: number; rate: number }> {
+  const from = fromCurrency.toLowerCase();
+  const to = toCurrency.toLowerCase();
+
+  if (from === to || amount === 0) {
+    return { amount, rate: 1 };
+  }
+
+  const rates = await getExchangeRates();
+  // rates[] is USD → X. Cross-rate: (USD → to) / (USD → from) = from → to
+  const usdToFrom = from === "usd" ? 1 : rates[from];
+  const usdToTo = to === "usd" ? 1 : rates[to];
+
+  if (!usdToFrom || !usdToTo) {
+    return { amount, rate: 1 };
+  }
+
+  const rate = usdToTo / usdToFrom;
+  const converted = amount * rate;
+  // Round to nearest cent for non-zero-decimal currencies, whole unit for JPY etc.
+  const rounded = isZeroDecimal(to) ? Math.round(converted) : Math.round(converted * 100) / 100;
+  return { amount: rounded, rate };
+}
+
+/**
+ * Common currencies operators will need to pick from in the budget form.
+ * Keep this list short — long pickers are decision paralysis. If someone
+ * needs an exotic currency we don't have, they can type it into "Other"
+ * (or we add it here). Order reflects real-world use by Toronto/NYC
+ * collectives: USD/CAD at top, then the main international DJ-fee currencies.
+ */
+export const SUPPORTED_CURRENCIES: Array<{ code: string; label: string }> = [
+  { code: "usd", label: "USD · US Dollar" },
+  { code: "cad", label: "CAD · Canadian Dollar" },
+  { code: "eur", label: "EUR · Euro" },
+  { code: "gbp", label: "GBP · British Pound" },
+  { code: "aud", label: "AUD · Australian Dollar" },
+  { code: "mxn", label: "MXN · Mexican Peso" },
+  { code: "brl", label: "BRL · Brazilian Real" },
+  { code: "jpy", label: "JPY · Japanese Yen" },
+  { code: "chf", label: "CHF · Swiss Franc" },
+  { code: "zar", label: "ZAR · South African Rand" },
+];
+
+/**
+ * Small city → currency map used to pre-select the collective's default
+ * currency at signup. Covers the nightlife cities we actually target;
+ * unknowns fall through to USD (safe default matching ticket settlement).
+ */
+const CITY_CURRENCY: Record<string, string> = {
+  toronto: "cad", montreal: "cad", vancouver: "cad", calgary: "cad", ottawa: "cad",
+  "new york": "usd", nyc: "usd", "los angeles": "usd", la: "usd",
+  miami: "usd", chicago: "usd", detroit: "usd", "san francisco": "usd", sf: "usd",
+  austin: "usd", atlanta: "usd", boston: "usd", philadelphia: "usd", philly: "usd",
+  london: "gbp", manchester: "gbp",
+  berlin: "eur", paris: "eur", amsterdam: "eur", barcelona: "eur", madrid: "eur",
+  milan: "eur", rome: "eur", ibiza: "eur",
+  sydney: "aud", melbourne: "aud",
+  tokyo: "jpy",
+  "mexico city": "mxn", cdmx: "mxn",
+  "sao paulo": "brl", "são paulo": "brl", rio: "brl",
+};
+
+/**
+ * Infer a sensible default currency from a city name. Returns "usd" if
+ * the city isn't in the map — safe fallback that matches how tickets
+ * settle today.
+ */
+export function currencyForCity(city: string | null | undefined): string {
+  if (!city) return "usd";
+  return CITY_CURRENCY[city.trim().toLowerCase()] ?? "usd";
+}

--- a/src/lib/supabase/database.types.ts
+++ b/src/lib/supabase/database.types.ts
@@ -434,6 +434,7 @@ export type Database = {
           bio: string | null
           city: string | null
           created_at: string
+          default_currency: string
           deleted_at: string | null
           description: string | null
           id: string
@@ -451,6 +452,7 @@ export type Database = {
           bio?: string | null
           city?: string | null
           created_at?: string
+          default_currency?: string
           deleted_at?: string | null
           description?: string | null
           id?: string
@@ -468,6 +470,7 @@ export type Database = {
           bio?: string | null
           city?: string | null
           created_at?: string
+          default_currency?: string
           deleted_at?: string | null
           description?: string | null
           id?: string
@@ -1272,6 +1275,7 @@ export type Database = {
           bar_minimum: number | null
           collective_id: string
           created_at: string
+          currency: string | null
           deleted_at: string | null
           description: string | null
           doors_at: string | null
@@ -1300,6 +1304,7 @@ export type Database = {
           bar_minimum?: number | null
           collective_id: string
           created_at?: string
+          currency?: string | null
           deleted_at?: string | null
           description?: string | null
           doors_at?: string | null
@@ -1328,6 +1333,7 @@ export type Database = {
           bar_minimum?: number | null
           collective_id?: string
           created_at?: string
+          currency?: string | null
           deleted_at?: string | null
           description?: string | null
           doors_at?: string | null
@@ -3626,4 +3632,3 @@ export const Constants = {
     },
   },
 } as const
-


### PR DESCRIPTION
## Summary

Rewrites the event creation Budget step around per-row currency + itemized expense categories, so Toronto collectives budgeting in CAD can enter a London DJ's fee in GBP without mental math — and so ads / graphic design / photo / video finally get tracked.

- **Event currency picker** at the top of the Budget step; seeded from the collective's new `default_currency` column.
- **Per-row currency pickers** for headliner expenses (talent fee + flights/hotel/transport/per-diem when international). Venue costs stay simple (always event currency).
- **Chip-add Production & Marketing section** — tap \`+ Ads\`, \`+ Graphic design\`, \`+ Photo\`, \`+ Video\`, or \`+ Custom\` to add a row. Already-added chips hide from the tray. Zero empty fields if the operator doesn't need a category.
- **\"Auto-fill estimates\"** sparkle button populates the four travel rows from origin + venue city + nights (existing estimator, denominated in event currency now).
- **FX snapshot at entry** — \`convertBetween()\` runs server-side in \`calculateBudget()\`; resolved items persist to \`expenses.metadata\` with \`original_amount\`, \`original_currency\`, \`fx_rate\`, \`fx_locked_at\` so later settlement math doesn't drift when rates move.
- **Result view** shows \`2000 USD → 2758 CAD\` per line so the operator can sanity-check conversions before trusting the grand total.
- **Settings page**: new \`Default currency\` card lets the collective set \`default_currency\` once via \`updateCollectiveCurrency()\`.

## Database

Migration \`add_multi_currency_budget_support\` (already applied):
- \`collectives.default_currency\` TEXT NOT NULL DEFAULT 'usd' + 3-letter ISO CHECK
- \`events.currency\` TEXT nullable (NULL = inherit from collective)
- No \`expenses\` changes — FX snapshot rides in the existing \`metadata\` JSONB

Supabase TS types regenerated.

## Economic model preserved

Profit = Gross − Expenses, still no fee gross-up (organizer keeps 100% of ticket price, buyer pays Nocturn's 7%+\$0.50 at checkout, Nocturn absorbs Stripe).

## Deferred to Phase 2

- Onboarding flow (new collectives still default to USD; flip in settings)
- Settlement screen multi-currency display (data is there, UI consumer next)
- Event edit form for multi-currency items (create-only for v1)

## Test plan

- [ ] Fresh wizard run as a Toronto collective: budget step opens in CAD
- [ ] Flip event currency to USD, enter \$2000 USD talent fee → resolved view shows \"2000 USD\" (no conversion)
- [ ] Keep event currency CAD, enter \$2000 USD talent fee → resolved view shows \"2000 USD → ~2760 CAD\" and grand total uses CAD
- [ ] Tap international headliner, set origin + nights, tap Auto-fill estimates → four travel rows populate in event currency
- [ ] Add + Ads chip → row appears, chip disappears; remove row → chip returns
- [ ] Add Custom chip → row appears with editable label
- [ ] Submit event → \`events.currency\` set correctly, \`expenses\` rows have \`amount\` in event currency + \`metadata\` with original amount/rate
- [ ] Settings → change default currency → next new event opens in new currency
- [ ] Existing P&L / finance pages still render (they read \`expenses.amount\`, which is now denormalized to event currency)

🤖 Generated with [Claude Code](https://claude.com/claude-code)