### PR TITLE
feat(edit-event + finance): multi-currency budget edit form + P&L fix

### DIFF
--- a/src/app/(dashboard)/dashboard/events/[eventId]/edit/edit-event-form.tsx
+++ b/src/app/(dashboard)/dashboard/events/[eventId]/edit/edit-event-form.tsx
@@ -3,6 +3,7 @@
 import { useState } from "react";
 import { useRouter } from "next/navigation";
 import { updateEvent } from "@/app/actions/events";
+import { SUPPORTED_CURRENCIES } from "@/lib/currency";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
@@ -17,6 +18,8 @@ import {
   Trash2,
   Save,
   DollarSign,
+  Megaphone,
+  Sparkles,
 } from "lucide-react";
 import Link from "next/link";
 
@@ -26,6 +29,31 @@ interface TierData {
   price: number;
   quantity: number;
 }
+
+interface ExpenseRow {
+  id?: string;           // present = existing row; absent = newly added in this session
+  category: string;
+  label: string;
+  amount: number;        // in the row's native currency
+  currency: string;      // ISO 4217 lowercase
+}
+
+// Chip tray for common expense categories. Tapping a chip adds a row with
+// the label + category prefilled. Keeps the empty form short; operators only
+// see rows for categories they actually use.
+const EXPENSE_CHIPS: Array<{ category: string; label: string }> = [
+  { category: "talent",         label: "Talent fee" },
+  { category: "flights",        label: "Flights" },
+  { category: "hotel",          label: "Hotel" },
+  { category: "transport",      label: "Transport" },
+  { category: "per_diem",       label: "Per diem" },
+  { category: "venue_rental",   label: "Venue rental" },
+  { category: "deposit",        label: "Deposit" },
+  { category: "ads",            label: "Ads" },
+  { category: "graphic_design", label: "Graphic design" },
+  { category: "photo",          label: "Photo" },
+  { category: "video",          label: "Video" },
+];
 
 interface EventData {
   id: string;
@@ -44,6 +72,9 @@ interface EventData {
   venueDeposit: number | null;
   venueCost: number | null;
   estimatedBarRevenue: number | null;
+  // v2 multi-currency budget
+  currency: string;
+  expenses: ExpenseRow[];
 }
 
 export function EditEventForm({ event }: { event: EventData }) {
@@ -67,6 +98,9 @@ export function EditEventForm({ event }: { event: EventData }) {
   const [venueDeposit, setVenueDeposit] = useState(event.venueDeposit ?? "");
   const [venueCostVal, setVenueCostVal] = useState(event.venueCost ?? "");
   const [estimatedBarRevenue, setEstimatedBarRevenue] = useState(event.estimatedBarRevenue ?? "");
+  const [eventCurrency, setEventCurrency] = useState(event.currency);
+  const [expenses, setExpenses] = useState<ExpenseRow[]>(event.expenses);
+  const [removedExpenseIds, setRemovedExpenseIds] = useState<string[]>([]);
 
   function addTier() {
     setTiers([...tiers, { name: "", price: 0, quantity: 0 }]);
@@ -84,6 +118,24 @@ export function EditEventForm({ event }: { event: EventData }) {
     const updated = [...tiers];
     updated[index] = { ...updated[index], [field]: value };
     setTiers(updated);
+  }
+
+  function addExpense(category: string, label: string) {
+    setExpenses((prev) => [...prev, { category, label, amount: 0, currency: eventCurrency }]);
+  }
+
+  function addCustomExpense() {
+    addExpense("other", "Custom expense");
+  }
+
+  function updateExpense(index: number, partial: Partial<ExpenseRow>) {
+    setExpenses((prev) => prev.map((e, i) => (i === index ? { ...e, ...partial } : e)));
+  }
+
+  function removeExpense(index: number) {
+    const row = expenses[index];
+    if (row.id) setRemovedExpenseIds((prev) => [...prev, row.id!]);
+    setExpenses((prev) => prev.filter((_, i) => i !== index));
   }
 
   async function handleSave() {
@@ -127,6 +179,18 @@ export function EditEventForm({ event }: { event: EventData }) {
       venueDeposit: venueDeposit ? Number(venueDeposit) : null,
       venueCost: venueCostVal ? Number(venueCostVal) : null,
       estimatedBarRevenue: estimatedBarRevenue ? Number(estimatedBarRevenue) : null,
+      currency: eventCurrency,
+      // Only send rows with a label — drops blank scaffolding without surprising the operator.
+      expenseItems: expenses
+        .filter((e) => e.label.trim().length > 0)
+        .map((e) => ({
+          id: e.id,
+          category: e.category,
+          label: e.label.trim(),
+          amount: Number(e.amount) || 0,
+          currency: e.currency.toLowerCase(),
+        })),
+      removedExpenseIds,
     });
 
     if (result.error) {
@@ -359,6 +423,120 @@ export function EditEventForm({ event }: { event: EventData }) {
             <div className="rounded-md bg-amber-500/10 border border-amber-500/20 p-3 text-sm text-amber-400">
               Your estimated bar revenue is below the bar minimum. You risk losing your ${venueDeposit || "deposit"}.
             </div>
+          )}
+        </CardContent>
+      </Card>
+
+      {/* Budget & Expenses (v2 multi-currency) */}
+      <Card>
+        <CardHeader>
+          <CardTitle className="flex items-center gap-2">
+            <Megaphone className="h-4 w-4 text-nocturn" />
+            Budget &amp; expenses
+          </CardTitle>
+        </CardHeader>
+        <CardContent className="space-y-4">
+          {/* Event currency */}
+          <div className="space-y-2 max-w-sm">
+            <Label htmlFor="eventCurrency">Report this event&apos;s budget in</Label>
+            <select
+              id="eventCurrency"
+              value={eventCurrency}
+              onChange={(e) => setEventCurrency(e.target.value)}
+              className="w-full bg-zinc-900 border border-white/10 rounded-xl px-3 text-sm text-white focus:border-nocturn/50 focus:outline-none min-h-[44px]"
+            >
+              {SUPPORTED_CURRENCIES.map((c) => (
+                <option key={c.code} value={c.code}>{c.label}</option>
+              ))}
+            </select>
+            <p className="text-[11px] text-muted-foreground">
+              Individual rows can be entered in any currency — totals convert to this one.
+            </p>
+          </div>
+
+          {/* Itemized expense rows */}
+          {expenses.length > 0 && (
+            <div className="space-y-3 border-t border-white/5 pt-4">
+              {expenses.map((row, i) => {
+                const showFxHint = row.currency.toLowerCase() !== eventCurrency.toLowerCase() && row.amount > 0;
+                return (
+                  <div key={row.id ?? `new-${i}`} className="space-y-1.5">
+                    <div className="flex items-center justify-between gap-2">
+                      <Input
+                        value={row.label}
+                        onChange={(e) => updateExpense(i, { label: e.target.value })}
+                        placeholder="Label"
+                        className="flex-1 bg-transparent border-0 p-0 text-xs text-muted-foreground focus:outline-none focus:text-white h-auto min-h-0"
+                      />
+                      <button
+                        type="button"
+                        onClick={() => removeExpense(i)}
+                        aria-label={`Remove ${row.label || "row"}`}
+                        className="text-muted-foreground/40 hover:text-red-400 transition-colors min-h-[28px] min-w-[28px] flex items-center justify-center"
+                      >
+                        <Trash2 className="h-3 w-3" />
+                      </button>
+                    </div>
+                    <div className="flex gap-1.5">
+                      <Input
+                        type="number"
+                        inputMode="decimal"
+                        min="0"
+                        step="0.01"
+                        placeholder="0"
+                        value={row.amount || ""}
+                        onChange={(e) => updateExpense(i, { amount: parseFloat(e.target.value) || 0 })}
+                        className="flex-1 bg-zinc-900 border-white/10 rounded-lg min-h-[40px] focus:border-nocturn/50"
+                      />
+                      <select
+                        value={row.currency}
+                        onChange={(e) => updateExpense(i, { currency: e.target.value })}
+                        aria-label={`${row.label || "Row"} currency`}
+                        className="bg-zinc-900 border border-white/10 rounded-lg px-2 text-sm text-white focus:border-nocturn/50 focus:outline-none min-h-[40px] min-w-[72px]"
+                      >
+                        {SUPPORTED_CURRENCIES.map((c) => (
+                          <option key={c.code} value={c.code}>{c.code.toUpperCase()}</option>
+                        ))}
+                      </select>
+                    </div>
+                    {showFxHint && (
+                      <p className="text-[10px] text-muted-foreground/60">
+                        Converts to {eventCurrency.toUpperCase()} on save
+                      </p>
+                    )}
+                  </div>
+                );
+              })}
+            </div>
+          )}
+
+          {/* Chip tray — hide chips already present */}
+          <div className="flex flex-wrap gap-2 border-t border-white/5 pt-4">
+            {EXPENSE_CHIPS.filter((c) => !expenses.some((e) => e.category === c.category)).map((c) => (
+              <button
+                key={c.category}
+                type="button"
+                onClick={() => addExpense(c.category, c.label)}
+                className="flex items-center gap-1.5 rounded-full border border-white/10 bg-zinc-900 px-3 py-1.5 text-xs text-zinc-300 hover:border-nocturn/40 hover:bg-nocturn/10 hover:text-white transition-all active:scale-[0.97] min-h-[36px]"
+              >
+                <Plus className="h-3 w-3" />
+                {c.label}
+              </button>
+            ))}
+            <button
+              type="button"
+              onClick={addCustomExpense}
+              className="flex items-center gap-1.5 rounded-full border border-white/10 bg-zinc-900 px-3 py-1.5 text-xs text-zinc-400 hover:border-nocturn/40 hover:bg-nocturn/10 hover:text-white transition-all active:scale-[0.97] min-h-[36px]"
+            >
+              <Sparkles className="h-3 w-3" />
+              Custom
+            </button>
+          </div>
+
+          {expenses.length === 0 && (
+            <p className="text-[11px] text-muted-foreground/60">
+              Tap a chip to add an expense row. Stored per-event — edits here update the P&amp;L.
+            </p>
           )}
         </CardContent>
       </Card>

--- a/src/app/(dashboard)/dashboard/events/[eventId]/edit/edit-event-form.tsx
+++ b/src/app/(dashboard)/dashboard/events/[eventId]/edit/edit-event-form.tsx
@@ -41,14 +41,18 @@ interface ExpenseRow {
 // Chip tray for common expense categories. Tapping a chip adds a row with
 // the label + category prefilled. Keeps the empty form short; operators only
 // see rows for categories they actually use.
+//
+// Venue rental + deposit are intentionally NOT here — they live on the
+// Venue Financials card above (scalar inputs writing directly to
+// events.venue_cost / events.venue_deposit). Keeping them on the scalar
+// card prevents the double-count that exists when the same cost shows up
+// both as an expense row AND as an events column value.
 const EXPENSE_CHIPS: Array<{ category: string; label: string }> = [
   { category: "talent",         label: "Talent fee" },
   { category: "flights",        label: "Flights" },
   { category: "hotel",          label: "Hotel" },
   { category: "transport",      label: "Transport" },
   { category: "per_diem",       label: "Per diem" },
-  { category: "venue_rental",   label: "Venue rental" },
-  { category: "deposit",        label: "Deposit" },
   { category: "ads",            label: "Ads" },
   { category: "graphic_design", label: "Graphic design" },
   { category: "photo",          label: "Photo" },

--- a/src/app/(dashboard)/dashboard/events/[eventId]/edit/page.tsx
+++ b/src/app/(dashboard)/dashboard/events/[eventId]/edit/page.tsx
@@ -75,11 +75,18 @@ export default async function EditEventPage({ params }: Props) {
   // carries the FX snapshot from when each row was first entered — we pass
   // the original amount+currency back so the operator edits in the currency
   // they typed, not the converted local value.
+  //
+  // Excluding venue_rental + deposit: those live on the Venue Financials
+  // scalar card and map to events.venue_cost / venue_deposit columns. Any
+  // existing rows with those categories (from the brief window where the
+  // wizard double-wrote) are invisible here, since the scalar card is the
+  // canonical editor for those costs.
   const { data: expenseRows } = await admin
     .from("expenses")
     .select("id, category, description, amount, metadata")
     .eq("event_id", eventId)
     .is("deleted_at", null)
+    .not("category", "in", '("venue_rental","deposit")')
     .order("created_at");
 
   const venue = event.venues as unknown as {

--- a/src/app/(dashboard)/dashboard/events/[eventId]/edit/page.tsx
+++ b/src/app/(dashboard)/dashboard/events/[eventId]/edit/page.tsx
@@ -33,13 +33,24 @@ export default async function EditEventPage({ params }: Props) {
   const { data: event } = await admin
     .from("events")
     .select(
-      "id, title, slug, description, starts_at, ends_at, doors_at, status, collective_id, venue_id, bar_minimum, venue_deposit, venue_cost, estimated_bar_revenue, venues(id, name, address, city, capacity)"
+      "id, title, slug, description, starts_at, ends_at, doors_at, status, collective_id, venue_id, bar_minimum, venue_deposit, venue_cost, estimated_bar_revenue, currency, venues(id, name, address, city, capacity)"
     )
     .eq("id", eventId)
     .is("deleted_at", null)
     .maybeSingle();
 
   if (!event || !collectiveIds.includes(event.collective_id)) notFound();
+
+  // Resolve event reporting currency: event override → collective default → usd.
+  let resolvedCurrency: string = (event.currency ?? "").toLowerCase();
+  if (!resolvedCurrency) {
+    const { data: collective } = await admin
+      .from("collectives")
+      .select("default_currency")
+      .eq("id", event.collective_id)
+      .maybeSingle();
+    resolvedCurrency = (collective?.default_currency ?? "usd").toLowerCase();
+  }
 
   // Only draft events can be edited
   if (event.status !== "draft") {
@@ -59,6 +70,17 @@ export default async function EditEventPage({ params }: Props) {
     .select("id, name, price, capacity, sort_order")
     .eq("event_id", eventId)
     .order("sort_order");
+
+  // Fetch itemized expenses (v2 multi-currency budget). The `metadata` JSONB
+  // carries the FX snapshot from when each row was first entered — we pass
+  // the original amount+currency back so the operator edits in the currency
+  // they typed, not the converted local value.
+  const { data: expenseRows } = await admin
+    .from("expenses")
+    .select("id, category, description, amount, metadata")
+    .eq("event_id", eventId)
+    .is("deleted_at", null)
+    .order("created_at");
 
   const venue = event.venues as unknown as {
     id: string;
@@ -108,6 +130,23 @@ export default async function EditEventPage({ params }: Props) {
     venueDeposit: event.venue_deposit ? Number(event.venue_deposit) : null,
     venueCost: event.venue_cost ? Number(event.venue_cost) : null,
     estimatedBarRevenue: event.estimated_bar_revenue ? Number(event.estimated_bar_revenue) : null,
+    currency: resolvedCurrency,
+    expenses:
+      expenseRows?.map((r) => {
+        const meta = (r.metadata ?? {}) as {
+          original_amount?: number;
+          original_currency?: string;
+        };
+        const originalAmount = typeof meta.original_amount === "number" ? meta.original_amount : Number(r.amount ?? 0);
+        const originalCurrency = typeof meta.original_currency === "string" ? meta.original_currency : resolvedCurrency;
+        return {
+          id: r.id,
+          category: r.category ?? "other",
+          label: r.description ?? "",
+          amount: originalAmount,
+          currency: originalCurrency,
+        };
+      }) ?? [],
   };
 
   return <EditEventForm event={eventData} />;

--- a/src/app/(dashboard)/dashboard/events/new/page.tsx
+++ b/src/app/(dashboard)/dashboard/events/new/page.tsx
@@ -2105,13 +2105,23 @@ export default function NewEventPage() {
         // Event currency = per-event override; createEvent falls back to the
         // collective's default_currency if null.
         currency: budgetDraft.eventCurrency,
-        // Persist the wizard's itemized budget so the P&L page and finance
-        // screens have the line-item breakdown with FX snapshots. Bar minimum
-        // is a threshold (revenue target), not an expense, so it rides along
-        // as a scalar.
+        // Venue cost + deposit are authoritatively stored on events.venue_cost
+        // and events.venue_deposit columns (not in the expenses table). The
+        // wizard's local state carries them as scalar fields in the event
+        // currency; passing them here keeps the P&L's profit math working
+        // without requiring the itemized list to carry them too.
         barMinimum: budgetDraft.barMinimum || null,
         venueCost: budgetDraft.venueRental || null,
-        expenseItems: budgetResult?.resolvedItems ?? null,
+        venueDeposit: budgetDraft.deposit || null,
+        // Itemized expense rows — EXCLUDING venue_rental + deposit. Those
+        // are already carried by venueCost / venueDeposit scalar fields
+        // above; writing them to expenses too would double-count in the
+        // finance P&L (which subtracts both the column AND the expenses sum).
+        expenseItems: budgetResult?.resolvedItems
+          ? budgetResult.resolvedItems.filter(
+              (it) => it.category !== "venue_rental" && it.category !== "deposit",
+            )
+          : null,
       });
 
       if (result.error) {

--- a/src/app/actions/event-financials.ts
+++ b/src/app/actions/event-financials.ts
@@ -19,7 +19,18 @@ export interface ExpenseRow {
   id: string;
   description: string;
   category: string;
+  // `amount` is always in the event's reporting currency (what the P&L sums).
   amount: number;
+  // FX snapshot from when the row was entered (populated by the wizard and
+  // edit form). When present + originalCurrency differs from the event
+  // currency, the P&L renders "3500 USD @ 1.38" alongside the converted
+  // amount so operators can tie it back to their bank statement / DJ invoice.
+  // Null for rows added before multi-currency support (legacy) or manually
+  // added post-event without currency metadata.
+  originalAmount: number | null;
+  originalCurrency: string | null;
+  fxRate: number | null;
+  fxLockedAt: string | null;
 }
 
 export interface RevenueLineRow {
@@ -137,7 +148,7 @@ export async function getEventFinancials(eventId: string): Promise<{ error: stri
         .in("status", ["paid", "checked_in"]),
       admin
         .from("expenses")
-        .select("id, description, category, amount")
+        .select("id, description, category, amount, metadata")
         .eq("event_id", eventId)
         .order("created_at"),
       admin
@@ -158,7 +169,15 @@ export async function getEventFinancials(eventId: string): Promise<{ error: stri
 
     const tiers = tiersRes.data ?? [];
     const tickets = ticketsRes.data ?? [];
-    const expenses = expensesRes.data ?? [];
+    // Exclude venue_rental + deposit from the itemized expenses view. Those
+    // values live authoritatively on events.venue_cost / events.venue_deposit
+    // columns and get subtracted from profitLoss separately below — including
+    // them here would double-count. (The wizard's multi-currency intake
+    // produces these rows so the operator can edit them by category; the
+    // columns remain the single source of truth for the P&L.)
+    const expenses = (expensesRes.data ?? []).filter(
+      (e) => e.category !== "venue_rental" && e.category !== "deposit",
+    );
     const revenueLinesData = revenueRes.data ?? [];
     const eventArtists = artistsRes.data ?? [];
 
@@ -176,13 +195,27 @@ export async function getEventFinancials(eventId: string): Promise<{ error: stri
       };
     });
 
-    // Build expense rows
-    const expenseRows: ExpenseRow[] = expenses.map((e) => ({
-      id: e.id,
-      description: e.description ?? "",
-      category: e.category ?? "other",
-      amount: Number(e.amount) || 0,
-    }));
+    // Build expense rows. Pull FX snapshot out of metadata so the P&L can
+    // render "Original: 3500 USD @ 1.38" next to the converted amount for any
+    // rows whose native currency differs from the event's reporting currency.
+    const expenseRows: ExpenseRow[] = expenses.map((e) => {
+      const meta = (e.metadata ?? {}) as {
+        original_amount?: number;
+        original_currency?: string;
+        fx_rate?: number;
+        fx_locked_at?: string;
+      };
+      return {
+        id: e.id,
+        description: e.description ?? "",
+        category: e.category ?? "other",
+        amount: Number(e.amount) || 0,
+        originalAmount: typeof meta.original_amount === "number" ? meta.original_amount : null,
+        originalCurrency: typeof meta.original_currency === "string" ? meta.original_currency : null,
+        fxRate: typeof meta.fx_rate === "number" ? meta.fx_rate : null,
+        fxLockedAt: typeof meta.fx_locked_at === "string" ? meta.fx_locked_at : null,
+      };
+    });
 
     // Build revenue line rows
     const revenueLineRows: RevenueLineRow[] = revenueLinesData.map((r) => ({

--- a/src/app/actions/events.ts
+++ b/src/app/actions/events.ts
@@ -84,6 +84,24 @@ interface UpdateEventInput {
   venueCost?: number | null;
   estimatedBarRevenue?: number | null;
   timezone?: string; // IANA timezone, defaults to America/Toronto
+  // ── Multi-currency budget (v2) ──
+  // Per-event currency override; NULL keeps the current value unchanged.
+  currency?: string | null;
+  // Itemized expenses. Reconciled against the `expenses` table:
+  //   id present → update in place (amount re-converted via event currency)
+  //   id absent  → insert new row
+  //   ids listed in `removedExpenseIds` → deleted
+  // If `expenseItems` is undefined, expenses are left untouched (the old
+  // edit-path behavior — handy so callers that don't know about expenses
+  // don't accidentally wipe them).
+  expenseItems?: Array<{
+    id?: string;
+    category: string;
+    label: string;
+    amount: number;    // in the row's native currency (`currency`)
+    currency: string;
+  }>;
+  removedExpenseIds?: string[];
 }
 
 export async function createEvent(input: CreateEventInput) {
@@ -643,6 +661,15 @@ export async function updateEvent(eventId: string, input: UpdateEventInput) {
     return { error: "Tier prices cannot be negative" };
   }
 
+  // Sanitize per-event currency override (ISO 4217 lowercase 3-letter).
+  // NULL/undefined keeps the column unchanged; empty string → clear it.
+  let nextEventCurrency: string | null | undefined = undefined;
+  if (input.currency === null || input.currency === "") {
+    nextEventCurrency = null;
+  } else if (typeof input.currency === "string" && /^[a-z]{3}$/.test(input.currency.toLowerCase())) {
+    nextEventCurrency = input.currency.toLowerCase();
+  }
+
   // Update event
   const eventUpdatePayload: Record<string, unknown> = {
     venue_id: venueId,
@@ -656,6 +683,9 @@ export async function updateEvent(eventId: string, input: UpdateEventInput) {
     venue_cost: input.venueCost ?? null,
     estimated_bar_revenue: input.estimatedBarRevenue ?? null,
   };
+  if (nextEventCurrency !== undefined) {
+    eventUpdatePayload.currency = nextEventCurrency;
+  }
   if (newSlug) {
     eventUpdatePayload.slug = newSlug;
   }
@@ -718,6 +748,112 @@ export async function updateEvent(eventId: string, input: UpdateEventInput) {
       if (tierError) {
         console.error("[updateEvent] tier insert error:", tierError.message);
         return { error: "Failed to add ticket tier" };
+      }
+    }
+  }
+
+  // ── Reconcile itemized expenses (v2 multi-currency) ──
+  // Only runs when expenseItems is explicitly provided — undefined means
+  // "leave existing expenses alone", which matches legacy behavior. Each
+  // input row is re-converted to the event's reporting currency at save
+  // time so the FX snapshot reflects the rate the operator actually
+  // committed to. Drafts only (page.tsx gates edit to draft status), so
+  // re-snapshotting rates doesn't drift historical data.
+  if (input.expenseItems !== undefined) {
+    // Resolve the event's reporting currency: explicit override on this
+    // update → existing event.currency → collective default → 'usd'.
+    let resolvedEventCurrency = nextEventCurrency ?? undefined;
+    if (!resolvedEventCurrency) {
+      const { data: eventRow } = await admin
+        .from("events")
+        .select("currency, collective_id")
+        .eq("id", eventId)
+        .maybeSingle();
+      resolvedEventCurrency = eventRow?.currency ?? undefined;
+      if (!resolvedEventCurrency && eventRow?.collective_id) {
+        const { data: collectiveRow } = await admin
+          .from("collectives")
+          .select("default_currency")
+          .eq("id", eventRow.collective_id)
+          .maybeSingle();
+        resolvedEventCurrency = collectiveRow?.default_currency ?? undefined;
+      }
+    }
+    const eventCurrency = (resolvedEventCurrency ?? "usd").toLowerCase();
+
+    // Delete explicitly-removed rows first, scoped to this event (defense
+    // in depth — the client could technically pass arbitrary IDs).
+    if (input.removedExpenseIds && input.removedExpenseIds.length > 0) {
+      const { error: delErr } = await admin
+        .from("expenses")
+        .delete()
+        .in("id", input.removedExpenseIds)
+        .eq("event_id", eventId);
+      if (delErr) {
+        console.error("[updateEvent] expense delete error:", delErr.message);
+        // Non-fatal; continue so upserts still land.
+      }
+    }
+
+    // Validate + re-convert each item.
+    const fxLockedAt = new Date().toISOString();
+    const { convertBetween } = await import("@/lib/currency");
+
+    for (const it of input.expenseItems) {
+      if (!Number.isFinite(it.amount) || it.amount < 0 || it.amount > 10_000_000) continue;
+      if (!/^[a-z]{3}$/.test(it.currency.toLowerCase())) continue;
+      const label = (it.label ?? "").toString().slice(0, 200);
+      const category = (it.category ?? "other").toString().slice(0, 50);
+      const rowCurrency = it.currency.toLowerCase();
+
+      const { amount: localAmountRaw, rate } = await convertBetween(
+        it.amount,
+        rowCurrency,
+        eventCurrency,
+      );
+      // Inline safeMoney equivalent — cap to NUMERIC(10,2), non-negative.
+      const localAmt =
+        !Number.isFinite(localAmountRaw) || localAmountRaw < 0 || localAmountRaw > 9999999.99
+          ? 0
+          : Math.round(localAmountRaw * 100) / 100;
+      if (localAmt <= 0) continue;
+
+      const metadata = {
+        original_amount: it.amount,
+        original_currency: rowCurrency,
+        local_currency: eventCurrency,
+        fx_rate: rate,
+        fx_locked_at: fxLockedAt,
+      } as Database["public"]["Tables"]["expenses"]["Insert"]["metadata"];
+
+      if (it.id) {
+        const { error: upErr } = await admin
+          .from("expenses")
+          .update({
+            description: label,
+            category,
+            amount: localAmt,
+            metadata,
+          })
+          .eq("id", it.id)
+          .eq("event_id", eventId); // tenancy guard
+        if (upErr) {
+          console.error("[updateEvent] expense update error:", upErr.message);
+        }
+      } else {
+        const { error: insErr } = await admin
+          .from("expenses")
+          .insert({
+            event_id: eventId,
+            collective_id: ownership.event.collective_id,
+            description: label,
+            category,
+            amount: localAmt,
+            metadata,
+          });
+        if (insErr) {
+          console.error("[updateEvent] expense insert error:", insErr.message);
+        }
       }
     }
   }

--- a/src/components/event-pnl-spreadsheet.tsx
+++ b/src/components/event-pnl-spreadsheet.tsx
@@ -1003,54 +1003,77 @@ export function EventPnlSpreadsheet({ financials }: Props) {
                 </tr>
               )}
 
-              {/* Custom Expenses (Editable) */}
-              {financials.expenses.map((expense) => (
-                <tr
-                  key={expense.id}
-                  className="border-b border-border/50 hover:bg-muted/20 transition-colors group"
-                >
-                  <td className="px-4 py-1.5 text-muted-foreground text-xs">
-                    {categoryLabel(expense.category)}
-                  </td>
-                  <td className="px-4 py-1.5">
-                    <EditableTextCell
-                      value={expense.description}
-                      onSave={async (v) => {
-                        await handleUpdateExpense(expense.id, "description", v);
-                      }}
-                    />
-                  </td>
-                  <td className="px-4 py-1.5 text-right">
-                    <div className="flex items-center justify-end">
-                      <span className="text-red-400 mr-1">(</span>
-                      <EditableAmountCell
-                        value={expense.amount}
+              {/* Custom Expenses (Editable). When a row was entered in a
+                  different currency than the event's reporting currency, a
+                  small secondary line surfaces the original amount + the FX
+                  rate captured at entry so operators can reconcile against
+                  the DJ invoice / bank statement without mental math. */}
+              {financials.expenses.map((expense) => {
+                const hasFxSnapshot =
+                  expense.originalAmount != null &&
+                  expense.originalCurrency != null &&
+                  expense.fxRate != null &&
+                  // Only flag when the origin actually diverged from the event currency.
+                  // Rows entered natively in the event currency carry a rate of 1.
+                  expense.fxRate !== 1;
+                return (
+                  <tr
+                    key={expense.id}
+                    className="border-b border-border/50 hover:bg-muted/20 transition-colors group"
+                  >
+                    <td className="px-4 py-1.5 text-muted-foreground text-xs align-top">
+                      {categoryLabel(expense.category)}
+                    </td>
+                    <td className="px-4 py-1.5">
+                      <EditableTextCell
+                        value={expense.description}
                         onSave={async (v) => {
-                          await handleUpdateExpense(expense.id, "amount", v);
+                          await handleUpdateExpense(expense.id, "description", v);
                         }}
                       />
-                      <span className="text-red-400 ml-0.5">)</span>
-                    </div>
-                  </td>
-                  {fLabels.map((_, i) => (
-                    <td key={i} className="px-3 py-1.5 text-right text-sm font-mono text-red-400/30">
-                      ({formatCurrency(expense.amount)})
+                      {hasFxSnapshot && (
+                        <p
+                          className="text-[10px] text-muted-foreground/70 mt-0.5"
+                          title={`Entered ${expense.originalAmount?.toLocaleString()} ${expense.originalCurrency?.toUpperCase()} at rate ${expense.fxRate?.toFixed(4)}${expense.fxLockedAt ? ` on ${new Date(expense.fxLockedAt).toISOString().slice(0, 10)}` : ""}`}
+                        >
+                          {expense.originalAmount?.toLocaleString()} {expense.originalCurrency?.toUpperCase()}
+                          {" · "}
+                          @ {expense.fxRate?.toFixed(3)}
+                        </p>
+                      )}
                     </td>
-                  ))}
-                  <td className="px-4 py-1.5 text-center">
-                    <Button
-                      variant="ghost"
-                      size="icon"
-                      aria-label="Delete expense"
-                      className="h-7 w-7 opacity-0 group-hover:opacity-100 text-red-400 hover:text-red-300 hover:bg-red-400/10 transition-all"
-                      onClick={() => handleDeleteExpense(expense.id)}
-                      disabled={isPending}
-                    >
-                      <Trash2 className="h-3.5 w-3.5" />
-                    </Button>
-                  </td>
-                </tr>
-              ))}
+                    <td className="px-4 py-1.5 text-right align-top">
+                      <div className="flex items-center justify-end">
+                        <span className="text-red-400 mr-1">(</span>
+                        <EditableAmountCell
+                          value={expense.amount}
+                          onSave={async (v) => {
+                            await handleUpdateExpense(expense.id, "amount", v);
+                          }}
+                        />
+                        <span className="text-red-400 ml-0.5">)</span>
+                      </div>
+                    </td>
+                    {fLabels.map((_, i) => (
+                      <td key={i} className="px-3 py-1.5 text-right text-sm font-mono text-red-400/30 align-top">
+                        ({formatCurrency(expense.amount)})
+                      </td>
+                    ))}
+                    <td className="px-4 py-1.5 text-center align-top">
+                      <Button
+                        variant="ghost"
+                        size="icon"
+                        aria-label="Delete expense"
+                        className="h-7 w-7 opacity-0 group-hover:opacity-100 text-red-400 hover:text-red-300 hover:bg-red-400/10 transition-all"
+                        onClick={() => handleDeleteExpense(expense.id)}
+                        disabled={isPending}
+                      >
+                        <Trash2 className="h-3.5 w-3.5" />
+                      </Button>
+                    </td>
+                  </tr>
+                );
+              })}
 
               {/* Add Expense Row */}
               <AddExpenseRow eventId={financials.eventId} />


### PR DESCRIPTION
## Summary

Follow-up to #62 with **three tightly-related changes** to the multi-currency budget feature:

1. **Edit-event form gets itemized multi-currency support** (original scope)
2. **Fixes a double-count bug** — #62 made the wizard write venue_rental/deposit both as expense rows AND scalar columns; the finance P&L subtracted both
3. **Surfaces original currency + FX rate** on every expense row in the P&L spreadsheet

## 1. Edit-event itemized multi-currency

- \`UpdateEventInput\` accepts \`currency\`, \`expenseItems\`, \`removedExpenseIds\`
- \`updateEvent\` reconciles the expenses table (update by ID, insert new, delete removed); re-converts each row via \`convertBetween()\` using resolved event currency (update override → \`events.currency\` → collective default → USD); persists fresh FX snapshot
- Edit page loads existing currency + expenses with metadata; reconstructs original amount + currency so operators edit in the currency they typed
- Edit form gets a \"Budget & expenses\" card — event currency picker + itemized rows with per-row currency + 9-chip tray (talent / flights / hotel / transport / per-diem / ads / graphic design / photo / video) + Custom

## 2. Double-count fix

**The bug:** #62 had the wizard call \`createEvent({ venueCost, venueDeposit, expenseItems })\` where \`expenseItems\` also contained venue_rental + deposit rows. Those got written to both \`events.venue_cost\`/\`venue_deposit\` columns AND the expenses table. \`getEventFinancials\` subtracts both:

\`\`\`ts
profitLoss = grossRevenue - totalExpenses - totalArtistFees
           - venueCostNum - venueDepositNum - barShortfall;
\`\`\`

So every event created via the new wizard had its venue cost debited twice. Same for deposit.

**The fix:**
- Wizard \`handleCreate\` filters venue_rental + deposit out of \`expenseItems\`
- Edit form chip tray drops those categories (scalar Venue Financials card is the authoritative editor)
- Edit page fetch excludes those categories from the expenses query
- \`getEventFinancials\` filters those categories from the expenses sum + returned list — this is the retroactive safety that corrects already-created events

## 3. Multi-currency P&L display

\`ExpenseRow\` gets \`originalAmount\` / \`originalCurrency\` / \`fxRate\` / \`fxLockedAt\` (all nullable). \`getEventFinancials\` reads them from \`expenses.metadata\`. The P&L spreadsheet renders a secondary line on rows whose native currency diverged — e.g. \`3500 USD · @ 1.380\` — with a tooltip showing the locked-in date.

Zero visual noise for same-currency events.

## Test plan

**Edit form:**
- [ ] Create event in USD with \$2000 USD talent fee → open edit → row shows \"2000 USD\" with no conversion hint
- [ ] Flip event currency to CAD on edit → row hints \"Converts to CAD on save\"
- [ ] Save → \`expenses.amount\` ≈ 2760 CAD, \`metadata\` carries \`original_amount: 2000\` + new \`fx_rate\` + new \`fx_locked_at\`
- [ ] Add + Photo chip → row appears → save → new \`expenses\` row persists
- [ ] Delete existing row → save → row gone (scoped by event_id)

**Bug fix:**
- [ ] Create new event via wizard with Venue rental \$2000 CAD → open P&L → venue cost appears ONCE
- [ ] For any existing buggy event (created via wizard post-#62): open P&L → venue cost no longer double-counted

**Multi-currency display:**
- [ ] Event in CAD with \$3500 USD talent fee → P&L shows \"4830 CAD\" on the amount cell + \"3500 USD · @ 1.380\" subtitle
- [ ] Hover subtitle → tooltip shows full rate + locked-in date

🤖 Generated with [Claude Code](https://claude.com/claude-code)