### PR TITLE
feat(events): Ticket holders panel for ticketed events (was always RSVPs)

### DIFF
--- a/src/app/(dashboard)/dashboard/events/[eventId]/page.tsx
+++ b/src/app/(dashboard)/dashboard/events/[eventId]/page.tsx
@@ -41,6 +41,8 @@ import { LiveTicketStats } from "@/components/events/live-ticket-stats";
 import { EventUpdatesComposer } from "@/components/events/event-updates-composer";
 import { listEventUpdatesPublic } from "@/app/actions/event-updates";
 import { RsvpLiveList } from "@/components/events/rsvp-live-list";
+import { TicketHoldersLiveList } from "@/components/events/ticket-holders-live-list";
+import { listEventTicketHolders } from "@/app/actions/ticket-holders";
 import { listEventRsvps } from "@/app/actions/rsvps";
 
 interface Props {
@@ -169,11 +171,13 @@ export default async function EventDetailPage({ params }: Props) {
 
   if (collectiveIds.length === 0) notFound();
 
-  // Fetch event with venue
+  // Fetch event with venue. event_mode + is_free drive whether we render
+  // the RSVPs widget (free/rsvp events) or the Ticket Holders widget
+  // (ticketed events) below.
   const { data: event } = await admin
     .from("events")
     .select(
-      "id, title, slug, description, starts_at, ends_at, doors_at, status, flyer_url, collective_id, venues(name, address, city, capacity)"
+      "id, title, slug, description, starts_at, ends_at, doors_at, status, flyer_url, collective_id, event_mode, is_free, venues(name, address, city, capacity)"
     )
     .eq("id", eventId)
     .is("deleted_at", null)
@@ -256,8 +260,20 @@ export default async function EventDetailPage({ params }: Props) {
   // Fetch existing updates for the composer
   const { updates: existingUpdates } = await listEventUpdatesPublic(eventId);
 
-  // Fetch RSVPs (with contact info — only visible to collective members)
-  const { rsvps: initialRsvps } = await listEventRsvps(eventId);
+  // Free / RSVP-mode events show the RSVPs widget. Ticketed events show the
+  // Ticket Holders widget (who actually paid + checked-in status + CSV).
+  // Fetch both lazily — only the active one is rendered, but keeping both
+  // fetches cheap avoids a conditional data-flow that breaks component
+  // initial state.
+  const isTicketedMode = event.event_mode === "ticketed" && !event.is_free;
+
+  const { rsvps: initialRsvps } = isTicketedMode
+    ? { rsvps: [] }
+    : await listEventRsvps(eventId);
+
+  const { holders: initialHolders } = isTicketedMode
+    ? await listEventTicketHolders(eventId)
+    : { holders: [] };
 
   const venue = event.venues as unknown as {
     name: string;
@@ -599,12 +615,15 @@ export default async function EventDetailPage({ params }: Props) {
       {/* External Ticket Data */}
       <ExternalTicketsFormWrapper eventId={event.id} />
 
-      {/* RSVPs — live updates from the public page */}
+      {/* Attendees widget — RSVPs for free/rsvp-mode events, Ticket holders
+          for ticketed events. Header label + content both switch based on
+          mode so "Going (17)" doesn't confuse operators looking at a paid
+          event's attendee list. */}
       <Card className="rounded-2xl border-border hover:border-nocturn/20 transition-all duration-200">
         <CardHeader className="pb-4">
           <CardTitle className="flex items-center gap-2 text-lg font-bold">
             <Users className="h-4 w-4 text-nocturn" />
-            RSVPs
+            {isTicketedMode ? "Ticket holders" : "RSVPs"}
             <span className="ml-auto inline-flex items-center gap-1.5 text-xs font-normal text-muted-foreground">
               <span className="h-1.5 w-1.5 rounded-full bg-green-500 animate-pulse" />
               Live
@@ -612,7 +631,11 @@ export default async function EventDetailPage({ params }: Props) {
           </CardTitle>
         </CardHeader>
         <CardContent>
-          <RsvpLiveList eventId={event.id} initialRsvps={initialRsvps} />
+          {isTicketedMode ? (
+            <TicketHoldersLiveList eventId={event.id} initialHolders={initialHolders} />
+          ) : (
+            <RsvpLiveList eventId={event.id} initialRsvps={initialRsvps} />
+          )}
         </CardContent>
       </Card>
 

--- a/src/app/(dashboard)/dashboard/events/new/page.tsx
+++ b/src/app/(dashboard)/dashboard/events/new/page.tsx
@@ -1314,6 +1314,53 @@ interface MoneyRowProps {
   onDelete?: () => void;
 }
 
+// Controlled numeric input with local string state so typing "0" actually
+// shows "0" (instead of the `value || ""` pattern that treated 0 as empty
+// and made it impossible to enter zero). Syncs external updates — like the
+// auto-fill travel button — back into the text when the parent's number
+// diverges from what the user last typed.
+function NumberInput({
+  value,
+  onChange,
+  placeholder,
+  className,
+  inputProps,
+}: {
+  value: number;
+  onChange: (n: number) => void;
+  placeholder?: string;
+  className?: string;
+  inputProps?: React.InputHTMLAttributes<HTMLInputElement>;
+}) {
+  const [text, setText] = useState<string>(value > 0 ? String(value) : "");
+  const prevExternal = useRef<number>(value);
+
+  useEffect(() => {
+    if (value === prevExternal.current) return;
+    prevExternal.current = value;
+    // Only sync from external if our local text no longer parses to the new value
+    // (prevents clobbering intermediate states like "1." → would reset to "1").
+    const asNum = parseFloat(text);
+    if (asNum !== value) setText(value > 0 ? String(value) : value === 0 ? "" : "");
+  }, [value, text]);
+
+  return (
+    <Input
+      type="number"
+      inputMode="decimal"
+      placeholder={placeholder ?? "0"}
+      value={text}
+      onChange={(e) => {
+        setText(e.target.value);
+        const parsed = parseFloat(e.target.value);
+        onChange(Number.isFinite(parsed) ? parsed : 0);
+      }}
+      className={className}
+      {...inputProps}
+    />
+  );
+}
+
 function MoneyRow({ label, placeholder, value, onChange, eventCurrency, Icon, onDelete }: MoneyRowProps) {
   // No client-side FX here — we'd need to ship rates to the browser. The
   // "≈ converted" hint fires when the user taps Calculate Budget (result
@@ -1338,12 +1385,10 @@ function MoneyRow({ label, placeholder, value, onChange, eventCurrency, Icon, on
         )}
       </div>
       <div className="flex gap-1.5">
-        <Input
-          type="number"
-          inputMode="decimal"
+        <NumberInput
+          value={value.amount}
+          onChange={(n) => onChange({ ...value, amount: n })}
           placeholder={placeholder ?? "0"}
-          value={value.amount || ""}
-          onChange={(e) => onChange({ ...value, amount: parseFloat(e.target.value) || 0 })}
           className="bg-zinc-900 border-white/10 rounded-lg min-h-[40px] focus:border-nocturn/50 flex-1"
         />
         <select
@@ -1572,31 +1617,25 @@ function BudgetStep({
           <div className="grid grid-cols-2 gap-3">
             <div className="space-y-1">
               <label className="text-xs text-muted-foreground">Room rental</label>
-              <Input
-                type="number"
-                placeholder="0"
-                value={draft.venueRental || ""}
-                onChange={(e) => setDraft(prev => ({ ...prev, venueRental: parseInt(e.target.value) || 0 }))}
+              <NumberInput
+                value={draft.venueRental}
+                onChange={(n) => setDraft(prev => ({ ...prev, venueRental: n }))}
                 className="bg-zinc-900 border-white/10 rounded-lg min-h-[40px] focus:border-nocturn/50"
               />
             </div>
             <div className="space-y-1">
               <label className="text-xs text-muted-foreground">Bar minimum</label>
-              <Input
-                type="number"
-                placeholder="0"
-                value={draft.barMinimum || ""}
-                onChange={(e) => setDraft(prev => ({ ...prev, barMinimum: parseInt(e.target.value) || 0 }))}
+              <NumberInput
+                value={draft.barMinimum}
+                onChange={(n) => setDraft(prev => ({ ...prev, barMinimum: n }))}
                 className="bg-zinc-900 border-white/10 rounded-lg min-h-[40px] focus:border-nocturn/50"
               />
             </div>
             <div className="space-y-1">
               <label className="text-xs text-muted-foreground">Deposit</label>
-              <Input
-                type="number"
-                placeholder="0"
-                value={draft.deposit || ""}
-                onChange={(e) => setDraft(prev => ({ ...prev, deposit: parseInt(e.target.value) || 0 }))}
+              <NumberInput
+                value={draft.deposit}
+                onChange={(n) => setDraft(prev => ({ ...prev, deposit: n }))}
                 className="bg-zinc-900 border-white/10 rounded-lg min-h-[40px] focus:border-nocturn/50"
               />
             </div>
@@ -1631,12 +1670,9 @@ function BudgetStep({
                     </button>
                   </div>
                   <div className="flex gap-1.5">
-                    <Input
-                      type="number"
-                      inputMode="decimal"
-                      placeholder="0"
-                      value={p.amount || ""}
-                      onChange={(e) => updateProdItem(i, { amount: parseFloat(e.target.value) || 0 })}
+                    <NumberInput
+                      value={p.amount}
+                      onChange={(n) => updateProdItem(i, { amount: n })}
                       className="bg-zinc-900 border-white/10 rounded-lg min-h-[40px] focus:border-nocturn/50 flex-1"
                     />
                     <select

--- a/src/app/actions/ticket-holders.ts
+++ b/src/app/actions/ticket-holders.ts
@@ -1,0 +1,125 @@
+"use server";
+
+import { createClient as createServerClient } from "@/lib/supabase/server";
+import { createAdminClient } from "@/lib/supabase/config";
+
+// ── Types ──
+
+export type TicketHolderStatus = "paid" | "checked_in" | "refunded" | "reserved";
+
+export interface TicketHolder {
+  id: string;
+  status: TicketHolderStatus;
+  full_name: string | null;
+  email: string | null;
+  tier_name: string | null;
+  price_paid: number;
+  currency: string;
+  checked_in_at: string | null;
+  created_at: string;
+}
+
+/**
+ * Fetch ticket holders for a ticketed event. Parallel to listEventRsvps but
+ * backed by the `tickets` table. Buyer identity resolves from three possible
+ * sources — preferring the most reliable (users table join) and falling back
+ * to the Stripe checkout metadata we captured, then finally the walk-in
+ * attendee_name column:
+ *
+ *   1. `users` row via `tickets.user_id` (registered buyers)
+ *   2. `tickets.metadata.customer_email` / `buyer_email` / `email` (Stripe guest checkout)
+ *   3. `tickets.attendee_name` (door comp / manual ticket)
+ *
+ * Returns `reserved` tickets too so operators can see in-flight Stripe
+ * sessions; UI filters them out of headline counts.
+ */
+export async function listEventTicketHolders(eventId: string): Promise<{
+  error: string | null;
+  holders: TicketHolder[];
+}> {
+  try {
+    if (!eventId?.trim()) return { error: "Event ID required", holders: [] };
+
+    const supabase = await createServerClient();
+    const { data: { user } } = await supabase.auth.getUser();
+    if (!user) return { error: "Not authenticated", holders: [] };
+
+    const admin = createAdminClient();
+
+    // Ownership check: caller must be a member of the collective that owns the event.
+    const { data: event } = await admin
+      .from("events")
+      .select("collective_id")
+      .eq("id", eventId)
+      .maybeSingle();
+    if (!event) return { error: "Event not found", holders: [] };
+
+    const { count: memberCount } = await admin
+      .from("collective_members")
+      .select("*", { count: "exact", head: true })
+      .eq("collective_id", event.collective_id)
+      .eq("user_id", user.id)
+      .is("deleted_at", null);
+    if (!memberCount) return { error: "Not authorized", holders: [] };
+
+    const { data: tickets, error: ticketsError } = await admin
+      .from("tickets")
+      .select(
+        `id, status, price_paid, currency, checked_in_at, created_at, attendee_name, metadata,
+         ticket_tiers ( name ),
+         users!tickets_user_id_fkey ( full_name, email )`,
+      )
+      .eq("event_id", eventId)
+      .order("created_at", { ascending: false });
+
+    if (ticketsError) {
+      console.error("[listEventTicketHolders] query error:", ticketsError.message);
+      return { error: "Failed to load ticket holders", holders: [] };
+    }
+
+    const holders: TicketHolder[] = (tickets ?? []).map((t) => {
+      // Structural cast — Supabase returns single-row relations as objects, not arrays,
+      // but the generated types widen to arrays. Narrow via `unknown` (not `any`).
+      const userRow = t.users as unknown as { full_name: string | null; email: string | null } | null;
+      const tierRow = t.ticket_tiers as unknown as { name: string | null } | null;
+      const meta = (t.metadata ?? {}) as {
+        customer_email?: string;
+        buyer_email?: string;
+        email?: string;
+        buyer_name?: string;
+        customer_name?: string;
+      };
+
+      const email =
+        userRow?.email ??
+        meta.customer_email ??
+        meta.buyer_email ??
+        meta.email ??
+        null;
+
+      const full_name =
+        userRow?.full_name ??
+        meta.customer_name ??
+        meta.buyer_name ??
+        t.attendee_name ??
+        null;
+
+      return {
+        id: t.id,
+        status: t.status as TicketHolderStatus,
+        full_name,
+        email,
+        tier_name: tierRow?.name ?? null,
+        price_paid: Number(t.price_paid) || 0,
+        currency: (t.currency ?? "usd").toLowerCase(),
+        checked_in_at: t.checked_in_at,
+        created_at: t.created_at,
+      };
+    });
+
+    return { error: null, holders };
+  } catch (err) {
+    console.error("[listEventTicketHolders]", err);
+    return { error: "Something went wrong", holders: [] };
+  }
+}

--- a/src/components/events/ticket-holders-live-list.tsx
+++ b/src/components/events/ticket-holders-live-list.tsx
@@ -1,0 +1,312 @@
+"use client";
+
+import { useEffect, useState, useTransition } from "react";
+import { createClient } from "@/lib/supabase/client";
+import {
+  listEventTicketHolders,
+  type TicketHolder,
+  type TicketHolderStatus,
+} from "@/app/actions/ticket-holders";
+import { Ticket, Mail, Check, RotateCcw, Circle, Copy, CheckCheck, Download } from "lucide-react";
+
+interface Props {
+  eventId: string;
+  initialHolders: TicketHolder[];
+}
+
+type Filter = TicketHolderStatus | "all";
+
+// Paid + checked_in are the "real" holders (money in, at the door or not).
+// Refunded surfaces for visibility (cancellations matter for settlement).
+// Reserved = Stripe Checkout session that hasn't completed — rarely useful
+// but worth leaving filterable rather than hiding outright.
+const STATUS_META: Record<TicketHolderStatus, { label: string; icon: typeof Check; color: string; bg: string }> = {
+  paid:       { label: "Paid",       icon: Check,    color: "text-green-400",  bg: "bg-green-500/10 ring-green-500/20" },
+  checked_in: { label: "Checked in", icon: CheckCheck, color: "text-nocturn",  bg: "bg-nocturn/10 ring-nocturn/30" },
+  refunded:   { label: "Refunded",   icon: RotateCcw, color: "text-zinc-400",  bg: "bg-zinc-500/10 ring-zinc-500/20" },
+  reserved:   { label: "Pending",    icon: Circle,   color: "text-yellow-400", bg: "bg-yellow-500/10 ring-yellow-500/20" },
+};
+
+function timeAgo(iso: string): string {
+  const diff = Date.now() - new Date(iso).getTime();
+  const s = Math.floor(diff / 1000);
+  if (s < 60) return "just now";
+  const m = Math.floor(s / 60);
+  if (m < 60) return `${m}m ago`;
+  const h = Math.floor(m / 60);
+  if (h < 24) return `${h}h ago`;
+  const d = Math.floor(h / 24);
+  if (d < 7) return `${d}d ago`;
+  return new Date(iso).toLocaleDateString("en", { month: "short", day: "numeric" });
+}
+
+function formatMoney(amount: number, currency: string): string {
+  const c = currency.toUpperCase();
+  return `${c === "USD" || c === "CAD" || c === "AUD" ? "$" : ""}${amount.toFixed(2)}${c !== "USD" ? ` ${c}` : ""}`;
+}
+
+export function TicketHoldersLiveList({ eventId, initialHolders }: Props) {
+  const [holders, setHolders] = useState<TicketHolder[]>(initialHolders);
+  const [, startTransition] = useTransition();
+  const [filter, setFilter] = useState<Filter>("all");
+  const [copiedAll, setCopiedAll] = useState(false);
+  const [flashId, setFlashId] = useState<string | null>(null);
+
+  // Realtime: any ticket insert/update/delete for this event triggers a refetch.
+  // Covers new purchases, check-ins, and refunds in one subscription.
+  useEffect(() => {
+    const supabase = createClient();
+    const channel = supabase
+      .channel(`tickets-live-${eventId}`)
+      .on(
+        "postgres_changes",
+        { event: "*", schema: "public", table: "tickets", filter: `event_id=eq.${eventId}` },
+        (payload) => {
+          startTransition(async () => {
+            const { holders: fresh } = await listEventTicketHolders(eventId);
+            setHolders(fresh);
+            const rowId =
+              (payload.new as { id?: string })?.id ?? (payload.old as { id?: string })?.id ?? null;
+            if (rowId) {
+              setFlashId(rowId);
+              setTimeout(() => setFlashId((cur) => (cur === rowId ? null : cur)), 2500);
+            }
+          });
+        },
+      )
+      .subscribe();
+
+    return () => {
+      supabase.removeChannel(channel);
+    };
+  }, [eventId]);
+
+  // Counts exclude reserved (in-flight Stripe sessions) from headline numbers.
+  const counts = {
+    paid: holders.filter((h) => h.status === "paid").length,
+    checked_in: holders.filter((h) => h.status === "checked_in").length,
+    refunded: holders.filter((h) => h.status === "refunded").length,
+    reserved: holders.filter((h) => h.status === "reserved").length,
+    total: holders.filter((h) => h.status !== "reserved").length,
+  };
+
+  // Revenue totals, grouped by currency so mixed-currency events don't
+  // lie about the number. Buyers typically pay in one currency per event
+  // (Stripe checkout currency), but allow for edge cases gracefully.
+  const revenueByCurrency = holders
+    .filter((h) => h.status === "paid" || h.status === "checked_in")
+    .reduce<Record<string, number>>((acc, h) => {
+      acc[h.currency] = (acc[h.currency] ?? 0) + h.price_paid;
+      return acc;
+    }, {});
+
+  const visible =
+    filter === "all"
+      ? holders.filter((h) => h.status !== "reserved") // hide pending by default
+      : holders.filter((h) => h.status === filter);
+
+  async function copyAllEmails() {
+    const emails = holders
+      .filter((h) => (h.status === "paid" || h.status === "checked_in") && h.email)
+      .map((h) => h.email as string);
+    if (emails.length === 0) return;
+    try {
+      await navigator.clipboard.writeText(emails.join(", "));
+      setCopiedAll(true);
+      setTimeout(() => setCopiedAll(false), 2000);
+    } catch {
+      // noop — clipboard may be blocked
+    }
+  }
+
+  function downloadCsv() {
+    const header = ["Name", "Email", "Status", "Tier", "Price Paid", "Currency", "Checked In At", "Purchased At"];
+    const rows = holders.map((h) => [
+      h.full_name ?? "",
+      h.email ?? "",
+      h.status,
+      h.tier_name ?? "",
+      h.price_paid.toFixed(2),
+      h.currency.toUpperCase(),
+      h.checked_in_at ?? "",
+      h.created_at,
+    ]);
+    const csv = [header, ...rows]
+      .map((row) =>
+        row
+          .map((cell) => {
+            const s = String(cell).replace(/"/g, '""');
+            return /[",\n]/.test(s) ? `"${s}"` : s;
+          })
+          .join(","),
+      )
+      .join("\n");
+    const blob = new Blob([csv], { type: "text/csv;charset=utf-8;" });
+    const url = URL.createObjectURL(blob);
+    const a = document.createElement("a");
+    a.href = url;
+    a.download = `ticket-holders-${eventId}.csv`;
+    document.body.appendChild(a);
+    a.click();
+    document.body.removeChild(a);
+    URL.revokeObjectURL(url);
+  }
+
+  if (holders.length === 0) {
+    return (
+      <div className="rounded-2xl border border-dashed border-border p-8 text-center">
+        <div className="mx-auto mb-3 flex h-10 w-10 items-center justify-center rounded-full bg-nocturn/10">
+          <Ticket className="h-5 w-5 text-nocturn" />
+        </div>
+        <p className="text-sm font-medium text-foreground">No ticket sales yet</p>
+        <p className="mt-1 text-xs text-muted-foreground">
+          As people buy tickets, they&apos;ll show up here in real time.
+        </p>
+      </div>
+    );
+  }
+
+  return (
+    <div className="space-y-4">
+      {/* Summary + actions */}
+      <div className="flex flex-wrap items-center gap-3">
+        <button
+          onClick={() => setFilter("all")}
+          className={`rounded-full px-3 py-1.5 text-xs font-semibold transition-all min-h-[44px] ${
+            filter === "all" ? "bg-nocturn text-white" : "bg-muted text-muted-foreground hover:bg-accent"
+          }`}
+        >
+          All <span className="opacity-70">({counts.total})</span>
+        </button>
+        <button
+          onClick={() => setFilter("paid")}
+          className={`rounded-full px-3 py-1.5 text-xs font-semibold transition-all min-h-[44px] ${
+            filter === "paid"
+              ? "bg-green-500/20 text-green-300 ring-1 ring-green-500/40"
+              : "bg-muted text-muted-foreground hover:bg-accent"
+          }`}
+        >
+          Paid <span className="opacity-70">({counts.paid})</span>
+        </button>
+        <button
+          onClick={() => setFilter("checked_in")}
+          className={`rounded-full px-3 py-1.5 text-xs font-semibold transition-all min-h-[44px] ${
+            filter === "checked_in"
+              ? "bg-nocturn/20 text-nocturn ring-1 ring-nocturn/40"
+              : "bg-muted text-muted-foreground hover:bg-accent"
+          }`}
+        >
+          Checked in <span className="opacity-70">({counts.checked_in})</span>
+        </button>
+        {counts.refunded > 0 && (
+          <button
+            onClick={() => setFilter("refunded")}
+            className={`rounded-full px-3 py-1.5 text-xs font-semibold transition-all min-h-[44px] ${
+              filter === "refunded"
+                ? "bg-zinc-500/20 text-zinc-300 ring-1 ring-zinc-500/40"
+                : "bg-muted text-muted-foreground hover:bg-accent"
+            }`}
+          >
+            Refunded <span className="opacity-70">({counts.refunded})</span>
+          </button>
+        )}
+
+        <div className="ml-auto flex items-center gap-2">
+          <button
+            onClick={copyAllEmails}
+            className="inline-flex items-center gap-1.5 rounded-xl border border-border bg-card px-3 py-1.5 text-xs font-medium text-muted-foreground hover:text-foreground hover:border-nocturn/30 transition-all min-h-[44px]"
+            title="Copy all paid + checked-in emails"
+          >
+            {copiedAll ? (
+              <>
+                <CheckCheck className="h-3 w-3 text-green-400" /> Copied
+              </>
+            ) : (
+              <>
+                <Copy className="h-3 w-3" /> Copy emails
+              </>
+            )}
+          </button>
+          <button
+            onClick={downloadCsv}
+            className="inline-flex items-center gap-1.5 rounded-xl border border-border bg-card px-3 py-1.5 text-xs font-medium text-muted-foreground hover:text-foreground hover:border-nocturn/30 transition-all min-h-[44px]"
+            title="Download CSV"
+          >
+            <Download className="h-3 w-3" /> CSV
+          </button>
+        </div>
+      </div>
+
+      {/* Revenue summary row — mixed currency aware */}
+      {Object.keys(revenueByCurrency).length > 0 && (
+        <div className="flex flex-wrap items-center gap-3 rounded-xl border border-border/60 bg-card/50 px-3 py-2 text-xs text-muted-foreground">
+          <span className="font-semibold text-foreground">Revenue</span>
+          {Object.entries(revenueByCurrency).map(([curr, amount]) => (
+            <span key={curr} className="font-mono">
+              {formatMoney(amount, curr)}
+            </span>
+          ))}
+          <span className="ml-auto text-muted-foreground/70">
+            {counts.checked_in} of {counts.paid + counts.checked_in} checked in
+          </span>
+        </div>
+      )}
+
+      {/* List */}
+      <ul className="space-y-2">
+        {visible.map((h) => {
+          const meta = STATUS_META[h.status];
+          const Icon = meta.icon;
+          const isFlash = flashId === h.id;
+          return (
+            <li
+              key={h.id}
+              className={`flex items-start gap-3 rounded-2xl border p-3 transition-all duration-500 ${
+                isFlash
+                  ? "border-nocturn/60 bg-nocturn/5 ring-1 ring-nocturn/30"
+                  : "border-border bg-card hover:border-nocturn/20"
+              }`}
+            >
+              <div
+                className={`flex h-9 w-9 shrink-0 items-center justify-center rounded-xl ring-1 ring-inset ${meta.bg}`}
+              >
+                <Icon className={`h-4 w-4 ${meta.color}`} />
+              </div>
+
+              <div className="min-w-0 flex-1">
+                <div className="flex flex-wrap items-baseline gap-x-2">
+                  <p className="font-semibold text-foreground truncate">
+                    {h.full_name || <span className="text-muted-foreground italic">Guest</span>}
+                  </p>
+                  {h.tier_name && (
+                    <span className="rounded-full bg-nocturn/10 px-2 py-0.5 text-[11px] font-semibold text-nocturn">
+                      {h.tier_name}
+                    </span>
+                  )}
+                  <span className={`text-[11px] font-medium ${meta.color}`}>{meta.label}</span>
+                  <span className="ml-auto text-[11px] text-muted-foreground/70">
+                    {timeAgo(h.created_at)}
+                  </span>
+                </div>
+
+                <div className="mt-0.5 flex flex-wrap items-center gap-x-3 gap-y-1">
+                  {h.email && (
+                    <a
+                      href={`mailto:${h.email}`}
+                      className="inline-flex items-center gap-1 text-xs text-muted-foreground hover:text-nocturn transition-colors"
+                    >
+                      <Mail className="h-3 w-3" /> {h.email}
+                    </a>
+                  )}
+                  <span className="text-xs text-muted-foreground/80 font-mono">
+                    {formatMoney(h.price_paid, h.currency)}
+                  </span>
+                </div>
+              </div>
+            </li>
+          );
+        })}
+      </ul>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary

Fixes the screenshot Shawn flagged: ticketed events were rendering an \"RSVPs\" widget with \"Going / Maybe / Can't make it\" filters — meaningless for paid tickets. Operators of ticketed events need to see who **paid** and who **checked in**, with revenue broken down by currency and a clean CSV export for reconciliation.

## What ships

- **\`listEventTicketHolders\` server action** — loads tickets + resolves buyer identity from `users` join → Stripe checkout metadata → `attendee_name`. Returns one row per ticket with name, email, tier, price, currency, status, checked-in-at.
- **\`TicketHoldersLiveList\` component** — Realtime subscription to the `tickets` table; flashes new purchases, check-ins, refunds. Status filter pills (Paid / Checked in / Refunded). Per-currency revenue summary header. Copy emails + CSV export.
- **Conditional render on event detail page** — \`isTicketedMode = event_mode === 'ticketed' && !is_free\`. Card title swaps between \"RSVPs\" and \"Ticket holders\". Free/RSVP events still get the existing widget unchanged.

## CSV export columns

\`Name, Email, Status, Tier, Price Paid, Currency, Checked In At, Purchased At\` — everything a collective's accountant or DJ-payout reconciliation needs.

## Test plan

- [ ] Create a ticketed event → buy a test ticket → /dashboard/events/[id] → \"Ticket holders\" panel shows the buyer with tier + price
- [ ] Buy second ticket → list updates live with the flash highlight
- [ ] Check in a ticket → row's status flips to \"Checked in\" without refresh
- [ ] Refund a ticket → \"Refunded\" filter pill appears, count updates
- [ ] Click CSV → file downloads with all 8 columns, names quoted properly
- [ ] Click Copy emails → only paid + checked-in addresses, comma-separated
- [ ] Free RSVP event still renders \"RSVPs\" widget unchanged

## What's NOT in this PR (parked for next session)

- Settlement multi-currency display (option #2 from the recommendations)
- Pitch demo seed extension (option #3)
- Bar minimum live tracker (option #4)
- Customer-facing login (plan delivered, build deferred until post-Techstars per recommendation)

🤖 Generated with [Claude Code](https://claude.com/claude-code)