### PR TITLE
fix(audit): MEDIUM deferred items \u2014 expense registry, rate limits, finance cache, dead dep, DB cleanup

### DIFF
--- a/package.json
+++ b/package.json
@@ -40,7 +40,6 @@
     "react-dom": "19.2.3",
     "replicate": "^1.4.0",
     "resend": "^6.9.4",
-    "shadcn": "^4.0.8",
     "stripe": "^20.4.1",
     "tailwind-merge": "^3.5.0",
     "tw-animate-css": "^1.4.0",

--- a/src/app/actions/budget-planner.ts
+++ b/src/app/actions/budget-planner.ts
@@ -3,25 +3,11 @@
 import { createClient as createServerClient } from "@/lib/supabase/server";
 import { convertBetween } from "@/lib/currency";
 import { cascadeScenario, cascadeBreakEven } from "@/lib/ticket-forecast";
-
-// ─── Expense categories ─────────────────────────────────────────────────────
-// Organizers think about expenses in buckets, not a flat list. These categories
-// drive the UI (chip-add for production/marketing) and the suggested-expense
-// auto-fill for international headliners (flights/hotel/transport/per_diem).
-export type ExpenseCategory =
-  | "talent"
-  | "flights"
-  | "hotel"
-  | "transport"
-  | "per_diem"
-  | "venue_rental"
-  | "bar_minimum"
-  | "deposit"
-  | "ads"
-  | "graphic_design"
-  | "photo"
-  | "video"
-  | "other";
+// Expense category union — canonical source is `src/lib/expense-categories.ts`
+// so budget-planner, event-financials, settlements, and the wizard chip tray
+// never drift. Re-exported here for callers still importing from this file.
+import type { ExpenseCategory } from "@/lib/expense-categories";
+export type { ExpenseCategory };
 
 export interface ExpenseItem {
   category: ExpenseCategory;

--- a/src/app/actions/company-financials.ts
+++ b/src/app/actions/company-financials.ts
@@ -1,5 +1,6 @@
 "use server";
 
+import { cache } from "react";
 import { createClient as createServerClient } from "@/lib/supabase/server";
 import { createAdminClient } from "@/lib/supabase/config";
 
@@ -49,13 +50,19 @@ export type RevenueForecastItem = {
   projectedProfit: number;
 };
 
-async function getCollectiveIds() {
+// Wrapped in `React.cache()` so the Finance page's 4 calls
+// (getCompanyFinancials + getEventFinancialSummaries + getRevenueForecast
+//  + anything else upstream) share a single auth.getUser() + membership
+// lookup per render. Was previously 4× round-trips per page load for a
+// query that never changes within one request. `cache()` memoizes on the
+// per-request basis, so cross-request isolation is preserved.
+const getCollectiveIds = cache(async () => {
   try {
     const supabase = await createServerClient();
     const {
       data: { user },
     } = await supabase.auth.getUser();
-    if (!user) return { user: null, collectiveIds: [] };
+    if (!user) return { user: null, collectiveIds: [] as string[] };
 
     const admin = createAdminClient();
     const { data: memberships, error } = await admin
@@ -66,7 +73,7 @@ async function getCollectiveIds() {
 
     if (error) {
       console.error("[getCollectiveIds] query error:", error.message);
-      return { user, collectiveIds: [] };
+      return { user, collectiveIds: [] as string[] };
     }
 
     const collectiveIds =
@@ -77,9 +84,9 @@ async function getCollectiveIds() {
     return { user, collectiveIds };
   } catch (err) {
     console.error("[getCollectiveIds] Unexpected error:", err);
-    return { user: null, collectiveIds: [] };
+    return { user: null, collectiveIds: [] as string[] };
   }
-}
+});
 
 export async function getCompanyFinancials(): Promise<{
   error: string | null;

--- a/src/app/actions/event-financials.ts
+++ b/src/app/actions/event-financials.ts
@@ -333,15 +333,10 @@ export async function getEventFinancials(eventId: string): Promise<{ error: stri
 
 // ── Add Expense ──────────────────────────────────────────────────────
 
-const VALID_EXPENSE_CATEGORIES = [
-  "talent", "venue", "production", "sound", "lighting",
-  "staffing", "security", "marketing", "hospitality",
-  "transportation", "equipment", "decor", "insurance",
-  "permits", "booking_fee",
-  // Legacy values still accepted for backward compat
-  "dj", "artist", "promotion", "staff", "miscellaneous",
-  "other",
-];
+// Canonical + legacy categories — single source of truth in
+// `@/lib/expense-categories` so this file, settlements.ts, budget-planner.ts,
+// and the wizard never diverge (they used to).
+import { ACCEPTED_EXPENSE_CATEGORIES as VALID_EXPENSE_CATEGORIES } from "@/lib/expense-categories";
 
 export async function addExpense(eventId: string, data: { description: string; category: string; amount: number }) {
   try {

--- a/src/app/actions/marketplace.ts
+++ b/src/app/actions/marketplace.ts
@@ -533,9 +533,19 @@ export async function sendInquiry(data: {
   } = await supabase.auth.getUser();
   if (!user) return { error: "Not logged in" };
 
-  // Rate limit: 5 inquiries per minute per user (sends email notifications)
+  // Rate limits: per-user (spam velocity) AND per (sender, recipient) pair
+  // (prevents one sender from repeatedly messaging the same target, which
+  // the per-user limit alone allows). Also triggers recipient email each
+  // time, so without the pair limit a single attacker can inbox-spam a
+  // target 5/min × N attackers without the target blocking them.
   const { success: rlOk } = await rateLimitStrict(`inquiry:${user.id}`, 5, 60_000);
   if (!rlOk) return { error: "Too many messages. Please wait a moment." };
+  const { success: pairOk } = await rateLimitStrict(
+    `inquiry:pair:${user.id}:${data.toProfileId}`,
+    1,
+    86_400_000, // one per target per day
+  );
+  if (!pairOk) return { error: "You've already messaged this collective today. Wait for their reply." };
 
   const admin = createAdminClient();
 

--- a/src/app/actions/settlements.ts
+++ b/src/app/actions/settlements.ts
@@ -5,6 +5,7 @@ import { createClient as createServerClient } from "@/lib/supabase/server";
 import { PLATFORM_FEE_PERCENT, PLATFORM_FEE_FLAT_CENTS } from "@/lib/pricing";
 import { createAdminClient } from "@/lib/supabase/config";
 import { isValidUUID } from "@/lib/utils";
+import { isAcceptedExpenseCategory } from "@/lib/expense-categories";
 
 // Generate a settlement for a completed event
 export async function generateSettlement(eventId: string) {
@@ -346,18 +347,13 @@ export async function addEventExpense(input: {
   amount: number;
 }) {
   try {
-  // Input validation
-  const VALID_EXPENSE_CATEGORIES = [
-    "talent", "venue", "production", "sound", "lighting", "staffing", "security",
-    "marketing", "hospitality", "transportation", "equipment", "decor", "insurance",
-    "permits", "booking_fee",
-    // Legacy values
-    "supply", "artist", "travel", "staff", "dj", "promotion", "miscellaneous",
-    "other",
-  ];
+  // Input validation — category list is shared via `@/lib/expense-categories`
+  // so this file, event-financials.ts, and the wizard all agree on what
+  // "valid" means (they used to diverge — `supply` and `travel` were only
+  // accepted here, `dj`/`artist` only on event-financials, etc.)
   if (!input.eventId || typeof input.eventId !== "string") return { error: "Invalid event ID" };
   if (!isValidUUID(input.eventId)) return { error: "Invalid event ID format" };
-  if (!VALID_EXPENSE_CATEGORIES.includes(input.category)) return { error: "Invalid expense category" };
+  if (!isAcceptedExpenseCategory(input.category)) return { error: "Invalid expense category" };
   if (!input.description || input.description.length > 500) return { error: "Description is required and must be under 500 characters" };
   if (!Number.isFinite(input.amount) || input.amount <= 0 || input.amount > 1000000) return { error: "Amount must be between $0.01 and $1,000,000" };
 

--- a/src/lib/expense-categories.ts
+++ b/src/lib/expense-categories.ts
@@ -1,0 +1,166 @@
+/**
+ * Canonical expense category registry.
+ *
+ * Previously three files diverged on what "valid expense categories" meant:
+ * - `event-financials.ts` accepted the newer finance-UI set
+ * - `settlements.ts` accepted a different legacy+new mix
+ * - `budget-planner.ts` declared its own `ExpenseCategory` union
+ *
+ * Result: a "talent" expense created via the budget step wasn't readable
+ * by all the places that rendered or categorized expenses; legacy values
+ * (`dj`, `artist`, `promotion`, `miscellaneous`, `staff`, `supply`, `travel`)
+ * were only accepted on SOME paths, so the same string could be valid on
+ * write and invalid on edit.
+ *
+ * This registry is the single source of truth. `CANONICAL_EXPENSE_CATEGORIES`
+ * drives the UI chip tray and the type system. `ACCEPTED_EXPENSE_CATEGORIES`
+ * adds legacy aliases we still accept on write for backward compatibility —
+ * displayed via `categoryLabel()` which maps anything unrecognized to
+ * "Other" rather than leaking raw strings to operators.
+ */
+
+/**
+ * Modern canonical categories. These drive:
+ * - wizard/edit chip tray
+ * - `ExpenseCategory` union type
+ * - display labels
+ *
+ * Keep in sync with the wizard's chip definitions in
+ * `src/app/(dashboard)/dashboard/events/new/page.tsx` + the edit form.
+ */
+export const CANONICAL_EXPENSE_CATEGORIES = [
+  "talent",
+  "flights",
+  "hotel",
+  "transport",
+  "per_diem",
+  "venue_rental",
+  "bar_minimum",
+  "deposit",
+  "ads",
+  "graphic_design",
+  "photo",
+  "video",
+  "other",
+] as const;
+
+export type ExpenseCategory = (typeof CANONICAL_EXPENSE_CATEGORIES)[number];
+
+/**
+ * Legacy category aliases still valid on write. Stored as-is in the DB so
+ * existing rows continue to round-trip. Readers should use `categoryLabel()`
+ * which maps these to the canonical display string.
+ *
+ * Removal plan: after a migration pass that rewrites legacy rows to their
+ * canonical equivalents, these can move to read-only.
+ */
+const LEGACY_EXPENSE_CATEGORIES = [
+  "venue",         // replaced by `venue_rental`
+  "production",    // replaced by `other`
+  "sound",         // replaced by `other`
+  "lighting",      // replaced by `other`
+  "staffing",      // replaced by `other` (fka `staff`, `dj`)
+  "security",      // replaced by `other`
+  "marketing",     // replaced by `ads`
+  "hospitality",   // replaced by `per_diem`
+  "transportation",// replaced by `transport`
+  "equipment",     // replaced by `other`
+  "decor",         // replaced by `other`
+  "insurance",     // replaced by `other`
+  "permits",       // replaced by `other`
+  "booking_fee",   // replaced by `other`
+  // Ancient legacy
+  "artist",
+  "dj",
+  "promotion",
+  "staff",
+  "miscellaneous",
+  "supply",
+  "travel",
+] as const;
+
+/**
+ * All categories that pass server-side input validation. Includes both
+ * canonical + legacy. Write-side gate for server actions.
+ */
+export const ACCEPTED_EXPENSE_CATEGORIES: readonly string[] = [
+  ...CANONICAL_EXPENSE_CATEGORIES,
+  ...LEGACY_EXPENSE_CATEGORIES,
+];
+
+export function isAcceptedExpenseCategory(c: unknown): c is string {
+  return typeof c === "string" && ACCEPTED_EXPENSE_CATEGORIES.includes(c);
+}
+
+/**
+ * Human-readable label for any category string — canonical, legacy, or unknown.
+ * Unknown strings render as "Other" so the UI never leaks raw identifiers.
+ */
+const CATEGORY_LABELS: Record<string, string> = {
+  talent: "Talent fee",
+  flights: "Flights",
+  hotel: "Hotel",
+  transport: "Transport",
+  per_diem: "Per diem",
+  venue_rental: "Venue rental",
+  bar_minimum: "Bar minimum",
+  deposit: "Deposit",
+  ads: "Ads",
+  graphic_design: "Graphic design",
+  photo: "Photo",
+  video: "Video",
+  other: "Other",
+  // Legacy aliases
+  venue: "Venue",
+  production: "Production",
+  sound: "Sound",
+  lighting: "Lighting",
+  staffing: "Staff",
+  security: "Security",
+  marketing: "Marketing",
+  hospitality: "Hospitality",
+  transportation: "Transport",
+  equipment: "Equipment",
+  decor: "Decor",
+  insurance: "Insurance",
+  permits: "Permits",
+  booking_fee: "Booking fee",
+  artist: "Artist",
+  dj: "DJ",
+  promotion: "Promotion",
+  staff: "Staff",
+  miscellaneous: "Misc",
+  supply: "Supplies",
+  travel: "Travel",
+};
+
+export function categoryLabel(category: string | null | undefined): string {
+  if (!category) return "Other";
+  return CATEGORY_LABELS[category] ?? "Other";
+}
+
+/**
+ * Set of categories the settlement + finance P&L excludes from the
+ * "itemized expenses" sum because they're already accounted for via
+ * dedicated columns on the events table. Keeping this shared so
+ * auto-settlement, settlements, and getEventFinancials can never drift.
+ */
+export const VENUE_CATEGORIES = new Set(["venue_rental", "deposit", "venue"]);
+
+/**
+ * Set of categories that represent headliner costs. When an event has
+ * `event_artists.fee` rows, matching expense-row amounts are filtered to
+ * prevent double-count (see per-artist pair logic in auto-settlement).
+ */
+export const HEADLINER_CATEGORIES = new Set([
+  "talent",
+  "flights",
+  "hotel",
+  "transport",
+  "per_diem",
+  // Legacy equivalents — an old event row with category='artist' should
+  // also dedupe against event_artists.fee.
+  "artist",
+  "dj",
+  "transportation",
+]);


### PR DESCRIPTION
Follow-up to PR #75 (audit sweep). Addresses the MEDIUM-severity findings deferred for a later pass.

## Changes

**Dead dep**: dropped \`shadcn\` from package.json (npm package unused; shadcn/ui components are vendored at \`src/components/ui/*\`). Kept \`@base-ui/react\` + \`tw-animate-css\` — audit was wrong about those; both are in active use.

**Expense category registry** (\`src/lib/expense-categories.ts\`): single source of truth for \`ExpenseCategory\` type + \`ACCEPTED_EXPENSE_CATEGORIES\` (canonical + legacy aliases) + \`categoryLabel()\` + \`VENUE_CATEGORIES\` / \`HEADLINER_CATEGORIES\` sets. Replaces two hand-maintained arrays in \`event-financials.ts\` and \`settlements.ts\` that had diverged (e.g. \`supply\`/\`travel\` only valid via settlements, \`dj\`/\`artist\` only via event-financials — same string was valid on write and invalid on edit).

**Marketplace per-pair inquiry rate limit**: \`sendInquiry\` now rejects repeat messages to the same recipient within 24h. Previous per-user 5/min limit still applies; the pair limit closes a loophole where one attacker could inbox-spam a target under their per-user budget.

**\`React.cache()\` on finance auth**: \`getCollectiveIds\` in \`company-financials.ts\` memoizes per-request. Finance page's 3 downstream actions now share one \`auth.getUser()\` + \`collective_members\` lookup instead of 4× roundtrips. Visible speed-up on every Finance page load.

**DB migration applied** (\`cleanup_legacy_venue_expense_rows\`): soft-deletes the orphan \`venue_rental\` + \`deposit\` expense rows the PR #62 wizard double-wrote during its brief live window (identified by \`metadata ? 'fx_rate'\` + 24h window). After PR #75 these rows were already filtered out of all money math via the shared category sets, but cleanup keeps the data store honest.

## Deferred from this PR (still in backlog)

- \`verifyOwnership\` extraction to \`lib/auth/ownership.ts\` — 60+ inline call sites, mechanical but wide blast radius
- Dashboard revenue RPC — needs SQL design
- Cron reminders batch (N+1 at 50+ events/day) — not in today's hot path
- \`events/new/page.tsx\` split (3155 lines)
- Unused index cleanup — needs monitoring window

## Test plan

- [ ] Finance page loads — should feel faster (4 \`collective_members\` queries collapsed to 1)
- [ ] Send 2 inquiries to the same collective in one day → second is rejected
- [ ] Add an expense with category \`transport\` → accepted; category \`junk\` → rejected with clear error
- [ ] Build / tsc pass clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)