### PR TITLE
perf(audit): dashboard revenue RPC + cron reminders batched + ownership helper

### DIFF
--- a/src/app/(dashboard)/dashboard/page.tsx
+++ b/src/app/(dashboard)/dashboard/page.tsx
@@ -116,12 +116,11 @@ export default async function DashboardPage() {
         .in("events.collective_id", collectiveIds)
         .in("status", ["paid", "checked_in"]),
 
-      // Revenue from paid tickets
-      admin
-        .from("tickets")
-        .select("price_paid, events!inner(collective_id)")
-        .in("events.collective_id", collectiveIds)
-        .in("status", ["paid", "checked_in"]),
+      // Revenue via aggregate RPC (was a full ticket fetch then JS SUM —
+      // unbounded, could ship 10K+ rows per dashboard render for a
+      // collective with years of history). RPC returns `total_revenue` +
+      // `ticket_count` as scalars.
+      admin.rpc("get_collective_revenue", { p_collective_ids: collectiveIds }),
 
       // Financial pulse (catch individually to prevent entire page crash)
       getFinancialPulse().catch((err) => { console.error("[dashboard] getFinancialPulse failed:", err); return null; }),
@@ -177,11 +176,9 @@ export default async function DashboardPage() {
     // Attendee count (already fetched in parallel above)
     totalAttendees = allEventsResult.count ?? 0;
 
-    // Revenue from actual ticket payments
-    totalRevenue = (revenueResult.data || []).reduce(
-      (sum: number, t: { price_paid: unknown }) => sum + (Number(t.price_paid) || 0),
-      0
-    );
+    // Revenue from actual ticket payments — via RPC, returns one row with
+    // `total_revenue` + `ticket_count` already summed server-side.
+    totalRevenue = Number(revenueResult.data?.[0]?.total_revenue ?? 0);
 
     // Setup checklist data
     totalEventsCount = totalEventsResult.count ?? 0;

--- a/src/app/actions/tasks.ts
+++ b/src/app/actions/tasks.ts
@@ -2,37 +2,9 @@
 
 import { createClient as createServerClient } from "@/lib/supabase/server";
 import { createAdminClient } from "@/lib/supabase/config";
-
-/** Verify user has access to an event via collective membership */
-async function verifyEventAccess(userId: string, eventId: string): Promise<boolean> {
-  try {
-    const admin = createAdminClient();
-    const { data: event, error: eventError } = await admin
-      .from("events")
-      .select("collective_id")
-      .eq("id", eventId)
-      .maybeSingle();
-    if (eventError) {
-      console.error("[verifyEventAccess] event lookup error:", eventError);
-      return false;
-    }
-    if (!event) return false;
-    const { count, error: memberError } = await admin
-      .from("collective_members")
-      .select("*", { count: "exact", head: true })
-      .eq("collective_id", event.collective_id)
-      .eq("user_id", userId)
-      .is("deleted_at", null);
-    if (memberError) {
-      console.error("[verifyEventAccess] membership lookup error:", memberError);
-      return false;
-    }
-    return (count ?? 0) > 0;
-  } catch (err) {
-    console.error("[verifyEventAccess]", err);
-    return false;
-  }
-}
+// Canonical ownership check. Previously a local copy of this function —
+// now shared with guest-list/promo-codes/ai-theme via `src/lib/auth/ownership`.
+import { verifyEventOwnership as verifyEventAccess } from "@/lib/auth/ownership";
 
 /** Auth + ownership check. Returns userId if authorized, null otherwise. */
 async function authAndVerifyEvent(eventId: string): Promise<string | null> {

--- a/src/app/api/cron/reminders/route.ts
+++ b/src/app/api/cron/reminders/route.ts
@@ -65,23 +65,23 @@ export async function GET(request: Request) {
       .lt("starts_at", todayEnd.toISOString())
       .limit(500);
 
-    for (const event of todayEvents ?? []) {
-      // Check if we already sent day-of hype for this event.
-      //
-      // CRITICAL: audit_logs has no `event_id` column — the correct FK is
-      // `record_id` (with `table_name = 'events'`). The old query filtered
-      // on a non-existent column, which PostgREST errored out on, leaving
-      // `count` as `null`. `(count ?? 0) > 0` then evaluated `false`, so
-      // the dedup check was completely bypassed and every cron run
-      // re-spammed every ticket holder "Tonight 🔥" until the event passed.
-      const { count } = await sb
+    // Batch dedup check — one query for all events instead of one per.
+    // On a 50-event day this drops 50 roundtrips to 1. Builds a Set of
+    // already-notified event_ids that we can O(1) test per event below.
+    const eventIds = (todayEvents ?? []).map((e) => e.id);
+    const alreadySent = new Set<string>();
+    if (eventIds.length > 0) {
+      const { data: sentLogs } = await sb
         .from("audit_logs")
-        .select("*", { count: "exact", head: true })
-        .eq("record_id", event.id)
+        .select("record_id")
         .eq("table_name", "events")
-        .eq("action", "day_of_hype_sent");
+        .eq("action", "day_of_hype_sent")
+        .in("record_id", eventIds);
+      for (const r of sentLogs ?? []) if (r.record_id) alreadySent.add(r.record_id);
+    }
 
-      if ((count ?? 0) > 0) continue;
+    for (const event of todayEvents ?? []) {
+      if (alreadySent.has(event.id)) continue;
 
       const venue = event.venues as unknown as { name: string; city: string } | null;
       const collective = event.collectives as unknown as { slug: string } | null;
@@ -169,16 +169,21 @@ export async function GET(request: Request) {
       .lte("starts_at", in48hr.toISOString())
       .limit(500);
 
-    for (const event of soonEvents ?? []) {
-      // Check if already sent — same FK fix as day-of hype above.
-      const { count } = await sb
+    // Batch dedup same as day-of-hype path above.
+    const soonIds = (soonEvents ?? []).map((e) => e.id);
+    const countdownAlreadySent = new Set<string>();
+    if (soonIds.length > 0) {
+      const { data: sentLogs } = await sb
         .from("audit_logs")
-        .select("*", { count: "exact", head: true })
-        .eq("record_id", event.id)
+        .select("record_id")
         .eq("table_name", "events")
-        .eq("action", "countdown_48hr_sent");
+        .eq("action", "countdown_48hr_sent")
+        .in("record_id", soonIds);
+      for (const r of sentLogs ?? []) if (r.record_id) countdownAlreadySent.add(r.record_id);
+    }
 
-      if ((count ?? 0) > 0) continue;
+    for (const event of soonEvents ?? []) {
+      if (countdownAlreadySent.has(event.id)) continue;
 
       // Get ticket stats
       const [{ count: ticketsSold }, { data: tiers }, { data: ticketRevenue }] = await Promise.all([
@@ -238,6 +243,7 @@ export async function GET(request: Request) {
   try {
     if (now.getDay() === 1) { // Monday only
       const thirtyDaysAgo = new Date(now.getTime() - 30 * 24 * 60 * 60 * 1000);
+      const monthStart = new Date(now.getFullYear(), now.getMonth(), 1);
 
       // Get all collectives with their last event
       const { data: collectives } = await sb
@@ -246,50 +252,73 @@ export async function GET(request: Request) {
         .is("deleted_at", null)
         .limit(100);
 
-      for (const col of collectives ?? []) {
-        // Check last event date
-        const { data: lastEvent } = await sb
+      const collectiveIds = (collectives ?? []).map((c) => c.id);
+
+      // Batch: last event per collective (one query instead of N).
+      // Previously ran a separate `order + limit 1` per collective — at
+      // 100 collectives that's 100 roundtrips; the whole cron started
+      // creeping on Vercel's 10s timeout. Here we pull every non-deleted
+      // event row for this set ordered by created_at desc, then keep the
+      // first (newest) hit per collective_id.
+      const lastEventByCollective = new Map<string, string>();
+      if (collectiveIds.length > 0) {
+        const { data: allRecentEvents } = await sb
           .from("events")
-          .select("created_at")
-          .eq("collective_id", col.id)
+          .select("collective_id, created_at")
+          .in("collective_id", collectiveIds)
           .is("deleted_at", null)
-          .order("created_at", { ascending: false })
-          .limit(1)
-          .maybeSingle();
+          .order("created_at", { ascending: false });
+        for (const ev of allRecentEvents ?? []) {
+          if (ev.collective_id && !lastEventByCollective.has(ev.collective_id)) {
+            lastEventByCollective.set(ev.collective_id, ev.created_at);
+          }
+        }
+      }
 
-        if (lastEvent && new Date(lastEvent.created_at) > thirtyDaysAgo) continue;
-
-        // Check if we already nudged this month. Old query filtered on
-        // `metadata->>collective_id` but audit_logs has no `metadata` column
-        // — the payload lives in `new_data`, and the collective id is
-        // stored as `record_id`. Same bug as day-of hype above → the dedup
-        // was bypassed, so inactive collectives received the nudge every
-        // Monday of the month instead of once.
-        const monthStart = new Date(now.getFullYear(), now.getMonth(), 1);
-        const { count: nudgeCount } = await sb
+      // Batch: already-nudged-this-month dedup (one query instead of N).
+      // Same bug history as the day-of-hype + countdown paths — nudge
+      // payload lives in `new_data`, collective id in `record_id`.
+      const nudgedThisMonth = new Set<string>();
+      if (collectiveIds.length > 0) {
+        const { data: nudgeLogs } = await sb
           .from("audit_logs")
-          .select("*", { count: "exact", head: true })
+          .select("record_id")
           .eq("action", "inactive_nudge_sent")
           .eq("table_name", "collectives")
-          .eq("record_id", col.id)
+          .in("record_id", collectiveIds)
           .gte("created_at", monthStart.toISOString());
+        for (const r of nudgeLogs ?? []) if (r.record_id) nudgedThisMonth.add(r.record_id);
+      }
 
-        if ((nudgeCount ?? 0) > 0) continue;
-
-        // Get admin
-        const { data: admins } = await sb
+      // Batch: admin lookup per collective (one query instead of N).
+      // Pull all admins for this set then group by collective_id.
+      const adminsByCollective = new Map<string, { email: string; full_name: string }>();
+      if (collectiveIds.length > 0) {
+        const { data: allAdmins } = await sb
           .from("collective_members")
-          .select("users(email, full_name)")
-          .eq("collective_id", col.id)
+          .select("collective_id, users(email, full_name)")
+          .in("collective_id", collectiveIds)
           .eq("role", "admin")
-          .is("deleted_at", null)
-          .limit(1);
+          .is("deleted_at", null);
+        for (const row of allAdmins ?? []) {
+          const user = row.users as unknown as { email: string; full_name: string } | null;
+          if (row.collective_id && user?.email && !adminsByCollective.has(row.collective_id)) {
+            adminsByCollective.set(row.collective_id, user);
+          }
+        }
+      }
 
-        const admin = admins?.[0]?.users as unknown as { email: string; full_name: string } | null;
+      for (const col of collectives ?? []) {
+        const lastEventCreatedAt = lastEventByCollective.get(col.id) ?? null;
+        if (lastEventCreatedAt && new Date(lastEventCreatedAt) > thirtyDaysAgo) continue;
+
+        if (nudgedThisMonth.has(col.id)) continue;
+
+        const admin = adminsByCollective.get(col.id) ?? null;
         if (!admin?.email) continue;
 
-        const lastDate = lastEvent
-          ? new Date(lastEvent.created_at).toLocaleDateString("en", { month: "long", day: "numeric" })
+        const lastDate = lastEventCreatedAt
+          ? new Date(lastEventCreatedAt).toLocaleDateString("en", { month: "long", day: "numeric" })
           : null;
 
         const html = inactiveNudgeEmail(col.name, admin.full_name?.split(" ")[0] ?? "there", lastDate);

--- a/src/lib/auth/ownership.ts
+++ b/src/lib/auth/ownership.ts
@@ -1,0 +1,120 @@
+/**
+ * Canonical ownership checks.
+ *
+ * Three near-identical `verifyEventAccess` implementations existed inline
+ * across `tasks.ts`, `guest-list.ts`, `promo-codes.ts`, and `ai-theme.ts`.
+ * Each one diverged in subtle ways — one cached `createAdminClient()`,
+ * another returned a `{ error, userId }` tuple, the promo-codes variant
+ * used the server client (RLS-subject) and re-derived the user internally,
+ * and ai-theme returned the event row itself. Same intent, three bugs
+ * waiting to drift apart.
+ *
+ * This module is the single source of truth. Keep per-file wrappers thin —
+ * call `verifyEventOwnership` / `verifyCollectiveOwnership` directly from
+ * server actions. All queries run through the admin client (bypassing RLS)
+ * so membership is validated against the canonical `collective_members`
+ * table regardless of the caller's session state; we still require a
+ * `userId` argument so the caller must have already authenticated.
+ */
+
+import { createAdminClient } from "@/lib/supabase/config";
+
+/**
+ * True if `userId` is an active (non-deleted) member of the collective
+ * that owns `eventId`. Returns false on any error or missing row — the
+ * callers treat this as "deny" which is the safe default.
+ */
+export async function verifyEventOwnership(
+  userId: string,
+  eventId: string
+): Promise<boolean> {
+  if (!userId || !eventId) return false;
+  try {
+    const admin = createAdminClient();
+    const { data: event, error: eventError } = await admin
+      .from("events")
+      .select("collective_id")
+      .eq("id", eventId)
+      .maybeSingle();
+    if (eventError) {
+      console.error("[verifyEventOwnership] event lookup error:", eventError);
+      return false;
+    }
+    if (!event) return false;
+    const { count, error: memberError } = await admin
+      .from("collective_members")
+      .select("*", { count: "exact", head: true })
+      .eq("collective_id", event.collective_id)
+      .eq("user_id", userId)
+      .is("deleted_at", null);
+    if (memberError) {
+      console.error("[verifyEventOwnership] membership lookup error:", memberError);
+      return false;
+    }
+    return (count ?? 0) > 0;
+  } catch (err) {
+    console.error("[verifyEventOwnership]", err);
+    return false;
+  }
+}
+
+/**
+ * True if `userId` is an active member of `collectiveId`. Used by actions
+ * that scope to a collective directly (settings, invitations, campaigns)
+ * rather than through an event.
+ */
+export async function verifyCollectiveOwnership(
+  userId: string,
+  collectiveId: string
+): Promise<boolean> {
+  if (!userId || !collectiveId) return false;
+  try {
+    const admin = createAdminClient();
+    const { count, error } = await admin
+      .from("collective_members")
+      .select("*", { count: "exact", head: true })
+      .eq("collective_id", collectiveId)
+      .eq("user_id", userId)
+      .is("deleted_at", null);
+    if (error) {
+      console.error("[verifyCollectiveOwnership] lookup error:", error);
+      return false;
+    }
+    return (count ?? 0) > 0;
+  } catch (err) {
+    console.error("[verifyCollectiveOwnership]", err);
+    return false;
+  }
+}
+
+/**
+ * Role-gated variant. Useful for "admin-only" server actions (payouts,
+ * deletes, member removal). Returns false if user is a member but not in
+ * the allowed roles list.
+ */
+export async function verifyCollectiveRole(
+  userId: string,
+  collectiveId: string,
+  allowedRoles: readonly string[]
+): Promise<boolean> {
+  if (!userId || !collectiveId || allowedRoles.length === 0) return false;
+  try {
+    const admin = createAdminClient();
+    const { data, error } = await admin
+      .from("collective_members")
+      .select("role")
+      .eq("collective_id", collectiveId)
+      .eq("user_id", userId)
+      .is("deleted_at", null)
+      .maybeSingle();
+    if (error) {
+      console.error("[verifyCollectiveRole] lookup error:", error);
+      return false;
+    }
+    if (!data?.role) return false;
+    return allowedRoles.includes(data.role);
+  } catch (err) {
+    console.error("[verifyCollectiveRole]", err);
+    return false;
+  }
+}

--- a/src/lib/supabase/database.types.ts
+++ b/src/lib/supabase/database.types.ts
@@ -3406,6 +3406,13 @@ export type Database = {
         }
         Returns: Json
       }
+      get_collective_revenue: {
+        Args: { p_collective_ids: string[] }
+        Returns: {
+          ticket_count: number
+          total_revenue: number
+        }[]
+      }
       get_user_collectives: { Args: never; Returns: string[] }
       has_collective_role: {
         Args: {


### PR DESCRIPTION
## Summary
- **Dashboard revenue**: replace unbounded `SELECT price_paid FROM tickets` + JS-sum with `get_collective_revenue` RPC (SECURITY DEFINER, locked search_path). A collective with 10K+ historical tickets no longer ships every row to the dashboard render.
- **Cron reminders batched**: the three loops in `/api/cron/reminders` (day-of-hype, countdown-48hr, inactive-nudge) each ran one dedup query per item against `audit_logs`. Pre-fetch once, Set-check, O(1) per iteration. At 50 events/day that's 150+ roundtrips dropped to 3. The Monday inactive-nudge path additionally batched last-event and admin lookups (100 collectives → 3 queries instead of 300).
- **Ownership helper consolidation**: `verifyEventAccess` was copy-pasted across 4 files with drift risk. Extracted to `src/lib/auth/ownership.ts` as `verifyEventOwnership` / `verifyCollectiveOwnership` / `verifyCollectiveRole`. Migrated `tasks.ts` (9 call sites) as proof-of-pattern; remaining call sites (guest-list, promo-codes, ai-theme) follow in a later sweep.

## DB migration (already applied to prod)
`add_collective_revenue_rpc` — creates `public.get_collective_revenue(uuid[])` returning `(total_revenue numeric, ticket_count bigint)`. REVOKE PUBLIC, GRANT authenticated+service_role.

## Test plan
- [ ] Dashboard home renders with revenue total matching prior JS-sum
- [ ] Vercel cron `/api/cron/reminders` run completes under 10s timeout with ≥50 events in the day-of-hype window
- [ ] Re-running cron within the same day does not double-send day-of-hype or countdown emails (dedup still holds)
- [ ] Monday-only inactive-nudge: re-run same Monday does not double-send; re-run next Monday of same calendar month still dedups
- [ ] `tasks.ts` server actions (create/update/complete) still enforce ownership — non-member cannot modify another collective's tasks

🤖 Generated with [Claude Code](https://claude.com/claude-code)