### PR TITLE
feat: live public guest list + finish ownership helper migration

### DIFF
--- a/src/app/(public)/e/[slug]/[eventSlug]/page.tsx
+++ b/src/app/(public)/e/[slug]/[eventSlug]/page.tsx
@@ -11,9 +11,10 @@ import { PastEvents } from "@/components/public-event/past-events";
 import { StickyTicketBar } from "@/components/public-event/sticky-ticket-bar";
 import { AlsoThisWeek } from "@/components/public-event/also-this-week";
 import { RsvpWidget } from "@/components/public-event/rsvp-widget";
+import { PublicRsvpList } from "@/components/public-event/public-rsvp-list";
 import { EventUpdatesFeed } from "@/components/public-event/event-updates-feed";
 import { createClient as createServerSupabaseClient } from "@/lib/supabase/server";
-import { getRsvpCounts, getMyRsvp, getRsvpByToken } from "@/app/actions/rsvps";
+import { getRsvpCounts, getMyRsvp, getRsvpByToken, listPublicEventRsvps } from "@/app/actions/rsvps";
 import { listEventUpdatesPublic } from "@/app/actions/event-updates";
 import type { Metadata } from "next";
 import Image from "next/image";
@@ -227,7 +228,7 @@ export default async function PublicEventPage({ params, searchParams }: Props) {
   const showTickets = (eventMode === "ticketed" || eventMode === "hybrid") && !isEffectivelyFree;
 
   // RSVP counts + current user's RSVP + event updates — fetched in parallel for RSVP/hybrid events
-  const [rsvpCountsResult, myRsvpResult, updatesResult, currentUserResult] = await Promise.all([
+  const [rsvpCountsResult, myRsvpResult, updatesResult, currentUserResult, publicRsvpsResult] = await Promise.all([
     showRsvp ? getRsvpCounts(event.id) : Promise.resolve({ error: null, counts: { yes: 0, maybe: 0, no: 0 } }),
     showRsvp ? getMyRsvp(event.id) : Promise.resolve({ error: null, rsvp: null }),
     listEventUpdatesPublic(event.id),
@@ -236,11 +237,15 @@ export default async function PublicEventPage({ params, searchParams }: Props) {
       const { data: { user } } = await ssr.auth.getUser();
       return user;
     })(),
+    showRsvp
+      ? listPublicEventRsvps(event.id)
+      : Promise.resolve({ error: null, rsvps: [] as Awaited<ReturnType<typeof listPublicEventRsvps>>["rsvps"] }),
   ]);
   const rsvpCounts = rsvpCountsResult.counts;
   let myRsvpStatus = myRsvpResult.rsvp?.status ?? null;
   const eventUpdates = updatesResult.updates;
   const isLoggedIn = !!currentUserResult;
+  const initialPublicRsvps = publicRsvpsResult.rsvps;
 
   // Pre-fill phone from the logged-in user's profile so the confirm form
   // doesn't force them to retype it every time.
@@ -628,6 +633,20 @@ export default async function PublicEventPage({ params, searchParams }: Props) {
                 isLoggedIn={isLoggedIn}
                 initialPhone={viewerPhone}
                 rsvpToken={rsvpToken ?? null}
+              />
+            </div>
+          )}
+
+          {/* ═══ LIVE GUEST LIST (free events) ═══
+              Partiful-style: first name + last initial, live counter,
+              avatar stack, flash animation on new RSVPs. Server strips
+              last names before they leave the server. */}
+          {isUpcoming && showRsvp && (
+            <div className="pb-10 border-t border-white/[0.04] pt-10">
+              <PublicRsvpList
+                eventId={event.id}
+                accentColor={accentColor}
+                initialRsvps={initialPublicRsvps}
               />
             </div>
           )}

--- a/src/app/actions/ai-theme.ts
+++ b/src/app/actions/ai-theme.ts
@@ -19,6 +19,7 @@
 
 import { createClient as createServerClient } from "@/lib/supabase/server";
 import { createAdminClient } from "@/lib/supabase/config";
+import { verifyEventOwnership } from "@/lib/auth/ownership";
 import { generateWithClaudeVision } from "@/lib/claude";
 import { revalidatePath } from "next/cache";
 import type { Json } from "@/lib/supabase/database.types";
@@ -93,26 +94,20 @@ function parseThemeJson(raw: string | null): EventTheme {
   }
 }
 
+// ai-theme callers need the event row (for its id / collective_id), not
+// just a boolean. Delegate the membership + soft-delete check to the
+// shared helper, then fetch the row once the gate passes.
 async function verifyEventAccess(userId: string, eventId: string) {
+  const ok = await verifyEventOwnership(userId, eventId);
+  if (!ok) return null;
   const admin = createAdminClient();
-
   const { data: event, error: eventErr } = await admin
     .from("events")
     .select("id, collective_id")
     .eq("id", eventId)
     .is("deleted_at", null)
     .maybeSingle();
-
   if (eventErr || !event) return null;
-
-  const { count } = await admin
-    .from("collective_members")
-    .select("*", { count: "exact", head: true })
-    .eq("collective_id", event.collective_id)
-    .eq("user_id", userId)
-    .is("deleted_at", null);
-
-  if (!count || count === 0) return null;
   return event;
 }
 

--- a/src/app/actions/guest-list.ts
+++ b/src/app/actions/guest-list.ts
@@ -5,8 +5,14 @@ import { createAdminClient } from "@/lib/supabase/config";
 import { sendEmail } from "@/lib/email/send";
 import { escapeHtml } from "@/lib/html";
 import { DEFAULT_TIMEZONE } from "@/lib/utils";
+import { verifyCollectiveRole } from "@/lib/auth/ownership";
 
-/** Verify the caller is an admin/member of the collective that owns this event */
+// Guest-list ops require a role stricter than plain membership —
+// door_staff / promoter / admin can manage the list, regular members
+// cannot. Composes the shared `verifyCollectiveRole` with an event
+// lookup rather than maintaining a second copy of the membership query.
+const GUEST_LIST_ROLES = ["admin", "promoter", "door_staff"] as const;
+
 async function verifyEventAccess(eventId: string): Promise<{ error: string | null; userId: string | null }> {
   try {
     const supabase = await createServerClient();
@@ -14,12 +20,11 @@ async function verifyEventAccess(eventId: string): Promise<{ error: string | nul
     if (!user) return { error: "Not authenticated", userId: null };
 
     const admin = createAdminClient();
-
-    // Get the event's collective
     const { data: event, error: eventError } = await admin
       .from("events")
       .select("collective_id")
       .eq("id", eventId)
+      .is("deleted_at", null)
       .maybeSingle();
 
     if (eventError) {
@@ -28,21 +33,8 @@ async function verifyEventAccess(eventId: string): Promise<{ error: string | nul
     }
     if (!event) return { error: "Event not found", userId: null };
 
-    // Check membership with role verification
-    const { data: membership, error: memberError } = await admin
-      .from("collective_members")
-      .select("role")
-      .eq("user_id", user.id)
-      .eq("collective_id", event.collective_id)
-      .in("role", ["admin", "promoter", "door_staff"])
-      .is("deleted_at", null)
-      .maybeSingle();
-
-    if (memberError) {
-      console.error("[verifyEventAccess]", memberError);
-      return { error: "Something went wrong", userId: null };
-    }
-    if (!membership) return { error: "You don't have access to this event", userId: null };
+    const hasRole = await verifyCollectiveRole(user.id, event.collective_id, GUEST_LIST_ROLES);
+    if (!hasRole) return { error: "You don't have access to this event", userId: null };
 
     return { error: null, userId: user.id };
   } catch (err) {

--- a/src/app/actions/promo-codes.ts
+++ b/src/app/actions/promo-codes.ts
@@ -4,8 +4,11 @@ import { createClient as createServerClient } from "@/lib/supabase/server";
 import { createAdminClient } from "@/lib/supabase/config";
 import { rateLimitStrict } from "@/lib/rate-limit";
 import { isValidUUID } from "@/lib/utils";
+import { verifyEventOwnership } from "@/lib/auth/ownership";
 
-// Verify user owns the event via collective membership
+// Thin wrapper over the shared ownership helper — preserves the original
+// `{ error, userId }` return shape so call sites don't have to change.
+// UUID validation up-front keeps callers from hitting the DB with junk.
 async function verifyEventAccess(eventId: string) {
   if (!isValidUUID(eventId)) return { error: "Invalid event ID", userId: null };
 
@@ -13,24 +16,8 @@ async function verifyEventAccess(eventId: string) {
   const { data: { user } } = await supabase.auth.getUser();
   if (!user) return { error: "Not authenticated", userId: null };
 
-  const admin = createAdminClient();
-  const { data: event } = await admin
-    .from("events")
-    .select("collective_id")
-    .eq("id", eventId)
-    .is("deleted_at", null)
-    .maybeSingle();
-
-  if (!event) return { error: "Event not found", userId: null };
-
-  const { count } = await admin
-    .from("collective_members")
-    .select("*", { count: "exact", head: true })
-    .eq("collective_id", event.collective_id)
-    .eq("user_id", user.id)
-    .is("deleted_at", null);
-
-  if (!count || count === 0) return { error: "You don't have access to this event", userId: null };
+  const ok = await verifyEventOwnership(user.id, eventId);
+  if (!ok) return { error: "You don't have access to this event", userId: null };
 
   return { error: null, userId: user.id };
 }

--- a/src/app/actions/rsvps.ts
+++ b/src/app/actions/rsvps.ts
@@ -480,6 +480,85 @@ export async function getMyRsvp(eventId: string): Promise<{
   }
 }
 
+// ── List RSVPs for the public event page (safe — no PII leak) ──
+//
+// Returns only what a Partiful-style live guest list needs:
+// first name + last initial, plus-ones count, status (yes/maybe only),
+// and created_at for ordering / flash-animation. NEVER exposes email,
+// phone, message, or the raw last name. Safe to call unauthenticated.
+//
+// Privacy contract: the server derives the display name here; the
+// client never receives `full_name`. If full_name is "Maya Kovalenko"
+// the client sees "Maya K.".
+
+function firstNameAndLastInitial(fullName: string | null): string | null {
+  if (!fullName) return null;
+  const parts = fullName.trim().split(/\s+/).filter(Boolean);
+  if (parts.length === 0) return null;
+  const first = parts[0];
+  if (parts.length === 1) return first;
+  const lastInitial = parts[parts.length - 1]!.charAt(0).toUpperCase();
+  return `${first} ${lastInitial}.`;
+}
+
+export async function listPublicEventRsvps(eventId: string): Promise<{
+  error: string | null;
+  rsvps: Array<{
+    id: string;
+    display_name: string | null;
+    status: "yes" | "maybe";
+    plus_ones: number;
+    created_at: string;
+  }>;
+}> {
+  try {
+    if (!eventId?.trim()) return { error: "Event ID required", rsvps: [] };
+    if (!/^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i.test(eventId)) {
+      return { error: "Invalid event ID", rsvps: [] };
+    }
+
+    const admin = createAdminClient();
+
+    // Don't leak attendee lists for draft / cancelled / deleted events.
+    const { data: event } = await admin
+      .from("events")
+      .select("id, status")
+      .eq("id", eventId)
+      .is("deleted_at", null)
+      .maybeSingle();
+    if (!event || event.status !== "published") {
+      return { error: null, rsvps: [] };
+    }
+
+    const { data, error } = await admin
+      .from("rsvps")
+      .select("id, status, full_name, plus_ones, created_at")
+      .eq("event_id", eventId)
+      .in("status", ["yes", "maybe"])
+      .order("created_at", { ascending: false })
+      .limit(500);
+
+    if (error) {
+      console.error("[listPublicEventRsvps]", error);
+      return { error: "Failed to load guest list", rsvps: [] };
+    }
+
+    return {
+      error: null,
+      rsvps: (data || []).map((r) => ({
+        id: r.id,
+        display_name: firstNameAndLastInitial(r.full_name),
+        status: r.status as "yes" | "maybe",
+        plus_ones: r.plus_ones ?? 0,
+        created_at: r.created_at,
+      })),
+    };
+  } catch (err) {
+    console.error("[listPublicEventRsvps]", err);
+    return { error: "Something went wrong", rsvps: [] };
+  }
+}
+
 // ── List RSVPs for a collective member (dashboard) ──
 
 export async function listEventRsvps(eventId: string): Promise<{

--- a/src/app/legal/privacy/page.tsx
+++ b/src/app/legal/privacy/page.tsx
@@ -10,7 +10,7 @@ export default function PrivacyPage() {
     <div className="min-h-dvh bg-background overflow-x-hidden">
       <div className="mx-auto max-w-3xl px-4 py-12 sm:px-6">
         <h1 className="text-3xl font-bold">Privacy Policy</h1>
-        <p className="mt-2 text-sm text-muted-foreground">Last updated: March 23, 2026</p>
+        <p className="mt-2 text-sm text-muted-foreground">Last updated: April 17, 2026</p>
 
         <div className="mt-8 space-y-8 text-sm leading-relaxed text-muted-foreground">
           <section>
@@ -19,8 +19,33 @@ export default function PrivacyPage() {
             <p className="mt-2"><strong className="text-foreground">Collective information:</strong> Collective name, city, description, social media handles, and member details.</p>
             <p className="mt-2"><strong className="text-foreground">Event data:</strong> Event titles, dates, venues, ticket tiers, pricing, and flyer images.</p>
             <p className="mt-2"><strong className="text-foreground">Payment information:</strong> Processed securely by Stripe. We do not store credit card numbers. We receive transaction confirmations including amounts and buyer email addresses.</p>
-            <p className="mt-2"><strong className="text-foreground">Attendee data:</strong> Email addresses of ticket purchasers, check-in status, and attendance history.</p>
+            <p className="mt-2"><strong className="text-foreground">Attendee data:</strong> Name, email address, phone number, check-in status, and attendance history of ticket purchasers and people who RSVP to events.</p>
+            <p className="mt-2"><strong className="text-foreground">RSVP data:</strong> When you RSVP to a free event, we collect your full name, email address, phone number, RSVP status (Going / Maybe / Can&apos;t go), plus-ones count, and any optional message you add.</p>
             <p className="mt-2"><strong className="text-foreground">Usage data:</strong> Pages visited, features used, and interactions with the Platform for improving the service.</p>
+          </section>
+
+          <section>
+            <h2 className="mb-3 text-lg font-semibold text-foreground">1a. RSVP &amp; Ticket Consent — Sharing With Event Organizers</h2>
+            <p>
+              When you submit an RSVP or purchase a ticket for an event on Nocturn, you <strong className="text-foreground">expressly consent</strong> to Nocturn sharing the following information with the event organizer (the collective, promoter, or individual running that event):
+            </p>
+            <ul className="list-disc pl-5 space-y-1 mt-2">
+              <li>Your full name</li>
+              <li>Your email address</li>
+              <li>Your phone number</li>
+              <li>Your RSVP status or ticket purchase</li>
+              <li>Your plus-ones count and any optional message you include</li>
+              <li>Check-in / attendance status on the night of the event</li>
+            </ul>
+            <p className="mt-2">
+              Organizers use this information to manage the guest list, contact you with event updates (venue changes, cancellations, lineup announcements), reconcile the door on event night, and follow up after the event (e.g., invitations to future events from that collective). You may unsubscribe from an organizer&apos;s marketing emails at any time.
+            </p>
+            <p className="mt-2">
+              <strong className="text-foreground">What other attendees and the public can see:</strong> On the public event page, only your <strong className="text-foreground">first name and last initial</strong> (e.g. &ldquo;Maya K.&rdquo;), your plus-ones count, and your RSVP status (Going or Maybe) are displayed. Your email address, phone number, and full last name are <strong className="text-foreground">never shown publicly</strong> and are never shared with other attendees. Declined RSVPs (&ldquo;Can&apos;t go&rdquo;) are never shown publicly.
+            </p>
+            <p className="mt-2">
+              <strong className="text-foreground">Your controls:</strong> You can change or delete your RSVP at any time using the confirmation link in your RSVP email. You can request that an organizer remove you from their attendee list by contacting them directly, or contact us at <a href="mailto:shawn@trynocturn.com" className="text-nocturn hover:underline">shawn@trynocturn.com</a> and we will pass the request on.
+            </p>
           </section>
 
           <section>
@@ -28,7 +53,9 @@ export default function PrivacyPage() {
             <ul className="list-disc pl-5 space-y-1">
               <li>To provide and maintain the Platform</li>
               <li>To process ticket purchases and settlements</li>
-              <li>To send transactional emails (ticket confirmations, settlement reports)</li>
+              <li>To send transactional emails (ticket confirmations, RSVP confirmations, settlement reports)</li>
+              <li>To share RSVP and ticket purchaser information with the relevant event organizer, as described in Section 1a</li>
+              <li>To display first name + last initial on public event pages so attendees can see who else is going</li>
               <li>To power AI features (content suggestions, financial forecasts)</li>
               <li>To improve the Platform based on usage patterns</li>
               <li>To communicate updates about the service</li>

--- a/src/components/public-event/public-rsvp-list.tsx
+++ b/src/components/public-event/public-rsvp-list.tsx
@@ -1,0 +1,298 @@
+"use client";
+
+import { useEffect, useRef, useState, useTransition } from "react";
+import { Users } from "lucide-react";
+import { createClient } from "@/lib/supabase/client";
+import { listPublicEventRsvps } from "@/app/actions/rsvps";
+
+interface PublicRsvp {
+  id: string;
+  display_name: string | null;
+  status: "yes" | "maybe";
+  plus_ones: number;
+  created_at: string;
+}
+
+interface Props {
+  eventId: string;
+  accentColor: string;
+  initialRsvps: PublicRsvp[];
+}
+
+function timeAgo(iso: string): string {
+  const diff = Date.now() - new Date(iso).getTime();
+  const s = Math.floor(diff / 1000);
+  if (s < 60) return "just now";
+  const m = Math.floor(s / 60);
+  if (m < 60) return `${m}m ago`;
+  const h = Math.floor(m / 60);
+  if (h < 24) return `${h}h ago`;
+  const d = Math.floor(h / 24);
+  return `${d}d ago`;
+}
+
+function initialsFromDisplay(name: string | null): string {
+  if (!name) return "?";
+  const parts = name.trim().split(/\s+/).filter(Boolean);
+  if (parts.length === 0) return "?";
+  if (parts.length === 1) return parts[0].charAt(0).toUpperCase();
+  // "Maya K." → M + K
+  return (parts[0].charAt(0) + parts[parts.length - 1].charAt(0)).toUpperCase();
+}
+
+/**
+ * Partiful-style live guest list for free / RSVP events.
+ *
+ * Privacy model:
+ * - Server action `listPublicEventRsvps` strips the last name to an initial
+ *   BEFORE sending to the client. Raw last names never leave the server.
+ * - Realtime subscription is best-effort: payload is IGNORED entirely; we
+ *   use the event as a "something changed" ping and refetch the sanitized
+ *   list via the server action. If RLS blocks the channel, the 12s poll
+ *   keeps the counter accurate.
+ */
+export function PublicRsvpList({ eventId, accentColor, initialRsvps }: Props) {
+  const [rsvps, setRsvps] = useState<PublicRsvp[]>(initialRsvps);
+  const [tab, setTab] = useState<"yes" | "maybe">("yes");
+  const [, startTransition] = useTransition();
+  const [flashId, setFlashId] = useState<string | null>(null);
+  const seenIdsRef = useRef<Set<string>>(
+    new Set(initialRsvps.map((r) => r.id))
+  );
+
+  useEffect(() => {
+    const supabase = createClient();
+    let cancelled = false;
+
+    async function refetch() {
+      const { rsvps: fresh } = await listPublicEventRsvps(eventId);
+      if (cancelled) return;
+      startTransition(() => {
+        setRsvps(fresh);
+        // Flash the newest row we've never seen — this is the Partiful
+        // dopamine hit. Don't flash on initial hydration since seenIdsRef
+        // was primed with initialRsvps.
+        for (const r of fresh) {
+          if (!seenIdsRef.current.has(r.id)) {
+            seenIdsRef.current.add(r.id);
+            setFlashId(r.id);
+            const id = r.id;
+            setTimeout(() => {
+              setFlashId((cur) => (cur === id ? null : cur));
+            }, 2500);
+            break;
+          }
+        }
+        for (const r of fresh) seenIdsRef.current.add(r.id);
+      });
+    }
+
+    // 12s poll — indistinguishable from "real-time" for an RSVP page and
+    // doesn't rely on realtime delivery at all. The poll is the floor.
+    const interval = setInterval(refetch, 12_000);
+
+    // Best-effort realtime ping. If RLS blocks SELECT for anon users the
+    // channel simply no-ops — no errors, no leaked payload, just falls
+    // back to the poll above.
+    const channel = supabase
+      .channel(`public-rsvps-${eventId}`)
+      .on(
+        "postgres_changes",
+        {
+          event: "*",
+          schema: "public",
+          table: "rsvps",
+          filter: `event_id=eq.${eventId}`,
+        },
+        () => {
+          refetch();
+        }
+      )
+      .subscribe();
+
+    return () => {
+      cancelled = true;
+      clearInterval(interval);
+      supabase.removeChannel(channel);
+    };
+  }, [eventId]);
+
+  const going = rsvps.filter((r) => r.status === "yes");
+  const maybe = rsvps.filter((r) => r.status === "maybe");
+  // Going count includes plus-ones (each +1 = one more body in the room).
+  // Maybe count is people only — plus-ones on maybes aren't real commitments.
+  const goingCount = going.reduce((sum, r) => sum + 1 + r.plus_ones, 0);
+  const maybeCount = maybe.length;
+
+  const visible = tab === "yes" ? going : maybe;
+  const avatarStackSource = going.slice(0, 8);
+  const overflowCount = Math.max(0, going.length - avatarStackSource.length);
+
+  // Empty state — show nothing jarring. The RSVP widget above already
+  // prompts people to RSVP; don't double up with a big empty panel.
+  if (rsvps.length === 0) {
+    return (
+      <div className="space-y-4">
+        <div className="flex items-center justify-between">
+          <h3 className="font-heading text-[11px] font-bold tracking-[0.3em] uppercase text-white/40">
+            Guest list
+          </h3>
+        </div>
+        <div className="rounded-2xl border border-dashed border-white/10 p-8 text-center">
+          <div
+            className="mx-auto mb-3 flex h-10 w-10 items-center justify-center rounded-full"
+            style={{ backgroundColor: `${accentColor}20` }}
+          >
+            <Users className="h-5 w-5" style={{ color: accentColor }} />
+          </div>
+          <p className="text-sm font-medium text-white/80">
+            Be the first to RSVP
+          </p>
+          <p className="mt-1 text-xs text-white/50">
+            Everyone who RSVPs will show up here live.
+          </p>
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <div className="space-y-4">
+      {/* Header row: section title + live counter */}
+      <div className="flex items-center justify-between">
+        <h3 className="font-heading text-[11px] font-bold tracking-[0.3em] uppercase text-white/40">
+          Guest list
+        </h3>
+        <div className="flex items-center gap-1.5">
+          <Users className="h-3.5 w-3.5" style={{ color: accentColor }} />
+          <span className="text-xs font-medium text-white/60">
+            {goingCount} going
+            {maybeCount > 0 ? ` · ${maybeCount} maybe` : ""}
+          </span>
+        </div>
+      </div>
+
+      {/* Avatar stack + headline count — the "social proof" strip */}
+      {avatarStackSource.length > 0 && (
+        <div className="flex items-center gap-3">
+          <div className="flex -space-x-2">
+            {avatarStackSource.map((r) => (
+              <div
+                key={r.id}
+                className="relative flex h-9 w-9 items-center justify-center rounded-full border-2 text-[11px] font-bold text-white"
+                style={{
+                  backgroundColor: `${accentColor}40`,
+                  borderColor: "#09090B",
+                }}
+                title={r.display_name ?? "Anonymous"}
+              >
+                {initialsFromDisplay(r.display_name)}
+              </div>
+            ))}
+            {overflowCount > 0 && (
+              <div
+                className="relative flex h-9 w-9 items-center justify-center rounded-full border-2 bg-white/10 text-[11px] font-semibold text-white/80"
+                style={{ borderColor: "#09090B" }}
+                aria-label={`+${overflowCount} more going`}
+              >
+                +{overflowCount}
+              </div>
+            )}
+          </div>
+          <p className="text-sm text-white/60">
+            <span className="font-semibold text-white">{goingCount}</span>{" "}
+            {goingCount === 1 ? "person is" : "people are"} going
+          </p>
+        </div>
+      )}
+
+      {/* Tabs — Going default, Maybe secondary */}
+      <div className="flex gap-2">
+        <button
+          type="button"
+          onClick={() => setTab("yes")}
+          className={`rounded-full px-3 py-1.5 text-xs font-semibold transition-all min-h-[36px] ${
+            tab === "yes"
+              ? "bg-white/10 text-white"
+              : "bg-transparent text-white/50 hover:text-white/80"
+          }`}
+        >
+          Going <span className="opacity-70">({goingCount})</span>
+        </button>
+        <button
+          type="button"
+          onClick={() => setTab("maybe")}
+          className={`rounded-full px-3 py-1.5 text-xs font-semibold transition-all min-h-[36px] ${
+            tab === "maybe"
+              ? "bg-white/10 text-white"
+              : "bg-transparent text-white/50 hover:text-white/80"
+          }`}
+          disabled={maybeCount === 0}
+        >
+          Maybe <span className="opacity-70">({maybeCount})</span>
+        </button>
+      </div>
+
+      {/* The list itself. role=status + aria-live so screen readers
+          announce new RSVPs the same way the organizer dashboard does. */}
+      <ul
+        className="space-y-2"
+        role="status"
+        aria-live="polite"
+        aria-atomic="false"
+      >
+        {visible.map((r) => {
+          const isFlash = flashId === r.id;
+          return (
+            <li
+              key={r.id}
+              className={`flex items-center gap-3 rounded-2xl border p-3 transition-all duration-500 ${
+                isFlash
+                  ? "bg-white/[0.04]"
+                  : "border-white/5 bg-white/[0.02]"
+              }`}
+              style={
+                isFlash
+                  ? {
+                      borderColor: `${accentColor}60`,
+                      boxShadow: `0 0 0 1px ${accentColor}30`,
+                    }
+                  : undefined
+              }
+            >
+              <div
+                className="flex h-9 w-9 shrink-0 items-center justify-center rounded-full text-[12px] font-bold text-white"
+                style={{ backgroundColor: `${accentColor}30` }}
+              >
+                {initialsFromDisplay(r.display_name)}
+              </div>
+              <div className="min-w-0 flex-1">
+                <div className="flex items-baseline gap-2">
+                  <p className="font-semibold text-white truncate">
+                    {r.display_name || (
+                      <span className="text-white/50 italic">Anonymous</span>
+                    )}
+                  </p>
+                  {r.plus_ones > 0 && (
+                    <span
+                      className="rounded-full px-2 py-0.5 text-[11px] font-semibold shrink-0"
+                      style={{
+                        backgroundColor: `${accentColor}20`,
+                        color: accentColor,
+                      }}
+                    >
+                      +{r.plus_ones}
+                    </span>
+                  )}
+                  <span className="ml-auto text-[11px] text-white/40 shrink-0">
+                    {timeAgo(r.created_at)}
+                  </span>
+                </div>
+              </div>
+            </li>
+          );
+        })}
+      </ul>
+    </div>
+  );
+}

--- a/src/components/public-event/rsvp-widget.tsx
+++ b/src/components/public-event/rsvp-widget.tsx
@@ -442,6 +442,13 @@ export function RsvpWidget({
           <p className="text-xs text-white/60">
             Your name, email, and phone so the organizer knows who&apos;s coming and can reach you with updates.
           </p>
+          <p className="text-[11px] text-white/40 leading-snug">
+            By submitting, you agree that Nocturn may share your name, email, and phone with the event organizer so they can contact you about this event. Your <span className="text-white/60">first name and last initial</span> will show on the public guest list (e.g. &ldquo;Maya K.&rdquo;); email and phone stay private to the organizer. See our{" "}
+            <a href="/legal/privacy" target="_blank" rel="noopener" className="underline underline-offset-2 hover:text-white/70">
+              Privacy Policy
+            </a>
+            .
+          </p>
           <input
             type="text"
             placeholder="Your full name"
@@ -533,6 +540,13 @@ export function RsvpWidget({
             {memberPhone
               ? "Confirm your phone so the organizer can reach you with updates."
               : "Add your phone so the organizer can reach you with updates."}
+          </p>
+          <p className="text-[11px] text-white/40 leading-snug">
+            By submitting, you agree that Nocturn may share your name, email, and phone with the event organizer so they can contact you about this event. Your <span className="text-white/60">first name and last initial</span> will show on the public guest list; email and phone stay private to the organizer. See our{" "}
+            <a href="/legal/privacy" target="_blank" rel="noopener" className="underline underline-offset-2 hover:text-white/70">
+              Privacy Policy
+            </a>
+            .
           </p>
           <div className="relative">
             <Phone className="absolute left-3.5 top-1/2 -translate-y-1/2 h-4 w-4 text-white/30" />

--- a/src/lib/auth/ownership.ts
+++ b/src/lib/auth/ownership.ts
@@ -31,10 +31,18 @@ export async function verifyEventOwnership(
   if (!userId || !eventId) return false;
   try {
     const admin = createAdminClient();
+    // Filter soft-deleted events — ownership over a deleted event is
+    // meaningless and lets mutations (tasks, promos, themes, etc.)
+    // run against rows the operator already "removed". Original
+    // tasks.ts + guest-list.ts omitted this filter; promo-codes.ts +
+    // ai-theme.ts added it. Strict default is the safer behavior —
+    // tightening tasks/guest-list matches their UI which already
+    // hides deleted events.
     const { data: event, error: eventError } = await admin
       .from("events")
       .select("collective_id")
       .eq("id", eventId)
+      .is("deleted_at", null)
       .maybeSingle();
     if (eventError) {
       console.error("[verifyEventOwnership] event lookup error:", eventError);


### PR DESCRIPTION
## Summary
- **Public live guest list** (Partiful-style) on free-event pages. First name + last initial only (e.g. "Maya K.") — full last name, email, phone, and the optional message never leave the server. Avatar stack, live counter, flash animation on new RSVPs. Gated on published+non-deleted events.
- **RSVP consent copy** added above the submit button explaining what gets shared with the organizer vs. what shows publicly, with a link to the updated privacy policy.
- **Privacy policy §1a**: documents the organizer-sharing contract, the public-visibility rule, and user removal controls.
- **Ownership helper migration complete**: `guest-list.ts`, `promo-codes.ts`, `ai-theme.ts` now compose the shared `verifyEventOwnership` / `verifyCollectiveRole` helpers instead of maintaining parallel copies. Call-site signatures preserved.
- **Security tightening**: `verifyEventOwnership` now filters soft-deleted events by default. Fixes a real bug class — mutations against deleted events previously passed ownership check on the tasks + guest-list code paths.

## Deferred: unused-index cleanup
Pulled out of this PR. Supabase stats show 76 "zero-scan" indexes over a 63-day window — but on inspection most underlying tables have <100 rows (e.g. `users`: 9, `events`: 27, `rsvps`: 24). Postgres uses seq scans on tiny tables regardless of index presence. Those indexes aren't unused because they're wrong — they're unused because the app is pre-launch. Dropping them now would degrade the first real customer's experience (login lookups, invitation tokens, promo codes, FK cascades). Re-audit after sustained production traffic.

## Test plan
- [ ] Publish a free event, submit an RSVP as user A — name appears as "FirstName I." in the guest list within 2s
- [ ] Inspect network response from `listPublicEventRsvps` — confirm no `email`, `phone`, `message`, or `full_name` fields
- [ ] RSVP form shows consent copy above submit; link to privacy policy opens §1a
- [ ] Submit "Can't go" RSVP — does NOT appear in public list
- [ ] Draft event — public list renders empty even if RSVPs exist
- [ ] Soft-delete an event, then try to create a task via API — ownership check now rejects (previously passed)
- [ ] Guest-list ops still require admin/promoter/door_staff role (regular member rejected)

🤖 Generated with [Claude Code](https://claude.com/claude-code)