### PR TITLE
Align app landing with trynocturn.com marketing design

### DIFF
--- a/src/app/(public)/page.tsx
+++ b/src/app/(public)/page.tsx
@@ -1,11 +1,12 @@
 import type { Metadata } from "next";
 import Link from "next/link";
 import { NocturnLogo } from "@/components/nocturn-logo";
+import { CinematicEffects } from "@/components/cinematic-effects";
 
 export const metadata: Metadata = {
   title: "Nocturn — You run the night. Nocturn runs the business.",
   description:
-    "The platform for everyone in nightlife. Events, ticketing, finance, a 16-role talent marketplace, and a built-in professional network — powered by AI.",
+    "The Agentic Work OS for nightlife. Book the talent. Fill the room. Settle the night — on autopilot.",
 };
 import {
   Calendar,
@@ -13,9 +14,6 @@ import {
   Sparkles,
   Users,
   Mic,
-  ArrowRight,
-  Zap,
-  Shield,
   MessageSquare,
   Music,
   MapPin,
@@ -42,105 +40,86 @@ const features = [
     title: "Event Management",
     description:
       "Create, publish, and manage events with ticketing, guest lists, and check-in — all from your phone.",
-    color: "text-nocturn-light",
-    bg: "bg-nocturn/15",
   },
   {
     icon: Sparkles,
     title: "AI Marketing",
     description:
       "Generate social posts, email campaigns, and promo content. Your AI marketing team, on demand.",
-    color: "text-nocturn-glow",
-    bg: "bg-nocturn-glow/10",
   },
   {
     icon: DollarSign,
     title: "Finance & Settlements",
     description:
       "Real-time P&L, artist settlements, expense tracking. Know your numbers before the night ends.",
-    color: "text-emerald-400",
-    bg: "bg-emerald-500/15",
   },
   {
     icon: Search,
     title: "Discover Marketplace",
     description:
       "Find and book from 16 professional roles — DJs, photographers, managers, designers, and more.",
-    color: "text-violet-400",
-    bg: "bg-violet-500/15",
   },
   {
     icon: Users2,
     title: "Your Network",
     description:
       "Every connection lives in one place. See who you've worked with, saved, and contacted — your nightlife rolodex.",
-    color: "text-cyan-400",
-    bg: "bg-cyan-500/15",
   },
   {
     icon: MessageSquare,
     title: "Team Sync & Chat",
     description:
       "Real-time chat with your collective and collab channels with other crews. Coordinate without the chaos.",
-    color: "text-amber-400",
-    bg: "bg-amber-500/15",
   },
   {
     icon: Mic,
     title: "Voice Recording",
     description:
       "Record calls with venues and artists. AI transcribes and extracts action items automatically.",
-    color: "text-pink-400",
-    bg: "bg-pink-500/15",
   },
   {
     icon: Users,
     title: "Attendee CRM",
     description:
       "Build your audience. Track who comes, who returns, and turn one-time guests into regulars.",
-    color: "text-orange-400",
-    bg: "bg-orange-500/15",
   },
 ];
 
 const marketplaceRoles = [
-  { icon: Music, label: "DJs & Artists", color: "text-nocturn-light", bg: "bg-nocturn/15" },
-  { icon: MapPin, label: "Venues", color: "text-emerald-400", bg: "bg-emerald-500/15" },
-  { icon: Users, label: "Collectives", color: "text-blue-400", bg: "bg-blue-500/15" },
-  { icon: Megaphone, label: "Promoters", color: "text-amber-400", bg: "bg-amber-500/15" },
-  { icon: Briefcase, label: "Artist Managers", color: "text-orange-400", bg: "bg-orange-500/15" },
-  { icon: Plane, label: "Tour Managers", color: "text-indigo-400", bg: "bg-indigo-500/15" },
-  { icon: CalendarCheck, label: "Booking Agents", color: "text-violet-400", bg: "bg-violet-500/15" },
-  { icon: Camera, label: "Photographers", color: "text-pink-400", bg: "bg-pink-500/15" },
-  { icon: Video, label: "Videographers", color: "text-red-400", bg: "bg-red-500/15" },
-  {
-    icon: () => <span className="text-lg">🎤</span>,
-    label: "MCs & Hosts",
-    color: "text-fuchsia-400",
-    bg: "bg-fuchsia-500/15",
-  },
-  { icon: Palette, label: "Graphic Designers", color: "text-rose-400", bg: "bg-rose-500/15" },
-  { icon: Speaker, label: "Sound & Production", color: "text-cyan-400", bg: "bg-cyan-500/15" },
-  { icon: Lightbulb, label: "Lighting & Visuals", color: "text-yellow-400", bg: "bg-yellow-500/15" },
-  { icon: UserCheck, label: "Event Staff", color: "text-slate-400", bg: "bg-slate-500/15" },
-  { icon: Newspaper, label: "PR & Publicists", color: "text-teal-400", bg: "bg-teal-500/15" },
-  { icon: BadgeDollarSign, label: "Sponsors & Brands", color: "text-green-400", bg: "bg-green-500/15" },
+  { icon: Music, label: "DJs & Artists" },
+  { icon: MapPin, label: "Venues" },
+  { icon: Users, label: "Collectives" },
+  { icon: Megaphone, label: "Promoters" },
+  { icon: Briefcase, label: "Artist Managers" },
+  { icon: Plane, label: "Tour Managers" },
+  { icon: CalendarCheck, label: "Booking Agents" },
+  { icon: Camera, label: "Photographers" },
+  { icon: Video, label: "Videographers" },
+  { icon: Mic, label: "MCs & Hosts" },
+  { icon: Palette, label: "Graphic Designers" },
+  { icon: Speaker, label: "Sound & Production" },
+  { icon: Lightbulb, label: "Lighting & Visuals" },
+  { icon: UserCheck, label: "Event Staff" },
+  { icon: Newspaper, label: "PR & Publicists" },
+  { icon: BadgeDollarSign, label: "Sponsors & Brands" },
 ];
 
 const stats = [
   { value: "16", label: "Professional roles" },
   { value: "100%", label: "Mobile-first" },
-  { value: "AI", label: "Powered workflows" },
-  { value: "7%", label: "Per ticket only" },
+  { value: "7% + $0.50", label: "Per ticket · buyer pays" },
 ];
 
 export default function HomePage() {
   return (
     <div className="relative min-h-dvh bg-background overflow-hidden">
+      {/* Cursor spotlight + magnetic CTAs (matches marketing site) */}
+      <CinematicEffects />
+
       {/* ── Ambient background effects ── */}
-      <div className="fixed inset-0 pointer-events-none">
-        <div className="absolute -top-40 -right-40 w-[600px] h-[600px] bg-nocturn/[0.07] rounded-full blur-[120px] animate-mesh-rotate" />
-        <div className="absolute -bottom-60 -left-40 w-[500px] h-[500px] bg-nocturn-teal/[0.04] rounded-full blur-[100px]" />
+      <div className="fixed inset-0 pointer-events-none z-0">
+        <div className="absolute -top-40 -right-40 w-[600px] h-[600px] bg-nocturn/[0.08] rounded-full blur-[120px] animate-mesh-rotate" />
+        <div className="absolute -bottom-60 -left-40 w-[500px] h-[500px] bg-nocturn-light/[0.06] rounded-full blur-[100px]" />
         <div className="absolute top-1/3 left-1/2 -translate-x-1/2 w-[800px] h-[400px] bg-nocturn/[0.03] rounded-full blur-[150px]" />
       </div>
 
@@ -156,64 +135,67 @@ export default function HomePage() {
           </Link>
           <Link
             href="/signup"
-            className="inline-flex h-11 items-center justify-center rounded-lg bg-gradient-to-r from-nocturn to-nocturn-light px-5 text-sm font-semibold text-white hover:shadow-lg hover:shadow-nocturn/25 hover:brightness-110 transition-all duration-300"
+            data-magnetic
+            className="inline-flex h-11 items-center justify-center rounded-lg bg-nocturn hover:bg-nocturn-light px-5 text-sm font-medium text-white transition-colors"
           >
-            Get Started
+            Start free
           </Link>
         </div>
       </nav>
 
       {/* ── Hero ── */}
-      <section className="relative z-10 px-6 pt-20 pb-28 max-w-6xl mx-auto">
+      <section className="relative z-10 px-6 pt-16 pb-24 max-w-6xl mx-auto">
         <div className="max-w-3xl">
-          <div className="inline-flex items-center gap-2 rounded-full border border-nocturn/20 bg-nocturn/[0.06] px-3 py-1 mb-8">
-            <Zap className="h-3.5 w-3.5 text-nocturn-light" />
-            <span className="text-xs font-medium text-nocturn-light tracking-wide">
-              The Platform for Everyone in Nightlife
-            </span>
+          <div className="eyebrow-pill mb-8">
+            <span className="eyebrow-pill-dot" />
+            THE AGENTIC WORK OS · NIGHTLIFE
           </div>
 
-          <h1 className="text-5xl sm:text-6xl md:text-7xl font-extrabold tracking-tight leading-[0.95]">
-            You run
+          <h1 className="font-heading text-[clamp(44px,7vw,80px)] font-semibold tracking-[-0.035em] leading-[0.98]">
+            You run the night.
             <br />
-            the night.
-            <br />
-            <span className="bg-gradient-to-r from-nocturn via-nocturn-light to-nocturn-glow bg-clip-text text-transparent">
-              Nocturn runs
-            </span>
-            <br />
-            the business.
+            <em className="not-italic text-nocturn-glow">
+              Nocturn runs the business.
+            </em>
           </h1>
 
-          <p className="mt-8 text-lg md:text-xl text-muted-foreground max-w-xl leading-relaxed">
-            Events, ticketing, finance, a 16-role talent marketplace, and a
-            built-in professional network. Whether you throw the events or make
-            them happen — this is your platform.
+          <p className="mt-7 text-lg md:text-xl text-muted-foreground max-w-xl leading-[1.5]">
+            The Agentic Work OS for nightlife. Book the talent. Fill the room.
+            Settle the night —{" "}
+            <span className="text-nocturn-glow">on autopilot.</span>
           </p>
 
-          <div className="mt-10 flex flex-wrap gap-4">
+          <div className="mt-10 flex flex-wrap gap-3">
             <Link
               href="/signup"
-              className="group inline-flex h-12 items-center justify-center rounded-xl bg-gradient-to-r from-nocturn to-nocturn-light px-8 text-base font-semibold text-white shadow-lg shadow-nocturn/25 hover:shadow-xl hover:shadow-nocturn/30 hover:brightness-110 transition-all duration-300"
+              data-magnetic
+              className="inline-flex h-12 items-center justify-center rounded-xl bg-nocturn hover:bg-nocturn-light px-7 text-base font-medium text-white transition-colors"
             >
-              Get Started
-              <ArrowRight className="ml-2 h-4 w-4 group-hover:translate-x-1 transition-transform" />
+              Start free →
             </Link>
             <Link
               href="/login"
-              className="inline-flex h-12 items-center justify-center rounded-xl border border-white/10 bg-white/[0.03] px-8 text-base font-medium hover:bg-white/[0.06] hover:border-white/20 transition-all duration-300"
+              className="inline-flex h-12 items-center justify-center rounded-xl border border-white/10 bg-white/[0.02] px-7 text-base font-medium hover:bg-white/[0.05] hover:border-white/20 transition-colors"
             >
-              Sign In
+              Sign in
             </Link>
           </div>
 
-          <div className="mt-16 flex gap-8 md:gap-14">
+          <p className="mt-5 text-xs font-mono text-muted-foreground/70 uppercase tracking-[0.12em]">
+            Free for operators · No credit card
+          </p>
+
+          {/* Stats (stat-trio pattern — matches marketing) */}
+          <div className="mt-14 grid grid-cols-1 sm:grid-cols-3 gap-px bg-white/[0.06] border border-white/[0.06] rounded-2xl overflow-hidden">
             {stats.map((stat) => (
-              <div key={stat.label}>
-                <p className="text-3xl md:text-4xl font-extrabold text-nocturn-light">
+              <div
+                key={stat.label}
+                className="bg-background px-6 py-7 flex flex-col gap-2 transition-colors hover:bg-white/[0.02]"
+              >
+                <p className="stat-cell-align text-[clamp(32px,4vw,44px)] font-semibold text-nocturn-glow leading-none">
                   {stat.value}
                 </p>
-                <p className="text-xs text-muted-foreground mt-1 uppercase tracking-wider">
+                <p className="text-[11px] font-mono text-muted-foreground uppercase tracking-[0.14em]">
                   {stat.label}
                 </p>
               </div>
@@ -225,13 +207,8 @@ export default function HomePage() {
       {/* ── Discover Marketplace ── */}
       <section className="relative z-10 px-6 py-24 max-w-6xl mx-auto">
         <div className="mb-12">
-          <div className="flex items-center gap-2 mb-4">
-            <Search className="h-4 w-4 text-nocturn-light" />
-            <span className="text-xs font-bold uppercase tracking-widest text-nocturn-light">
-              Discover Marketplace
-            </span>
-          </div>
-          <h2 className="text-3xl md:text-4xl font-extrabold tracking-tight mb-4">
+          <div className="section-label-mono mb-5">01 / THE NETWORK</div>
+          <h2 className="font-heading text-[clamp(30px,4vw,48px)] font-semibold tracking-[-0.03em] leading-[1.05] mb-4">
             Every role in the scene.
             <br />
             <span className="text-muted-foreground">One platform.</span>
@@ -243,20 +220,16 @@ export default function HomePage() {
           </p>
         </div>
 
-        <div className="grid grid-cols-2 sm:grid-cols-4 gap-3">
+        <div className="grid grid-cols-2 sm:grid-cols-4 gap-px bg-white/[0.06] border border-white/[0.06] rounded-2xl overflow-hidden">
           {marketplaceRoles.map((role) => {
             const Icon = role.icon;
             return (
               <Link
                 key={role.label}
                 href="/signup"
-                className="group flex items-center gap-3 rounded-xl bg-card/40 ring-1 ring-white/[0.06] p-4 transition-all duration-300 hover:ring-nocturn/30 hover:bg-card/60"
+                className="group flex items-center gap-3 bg-background p-5 transition-colors hover:bg-white/[0.02]"
               >
-                <div
-                  className={`flex h-9 w-9 items-center justify-center rounded-lg ${role.bg} shrink-0`}
-                >
-                  <Icon className={`h-4 w-4 ${role.color}`} />
-                </div>
+                <Icon className="h-4 w-4 text-nocturn-glow shrink-0" strokeWidth={1.5} />
                 <span className="text-sm font-medium truncate">
                   {role.label}
                 </span>
@@ -267,28 +240,25 @@ export default function HomePage() {
       </section>
 
       {/* ── Your Network ── */}
-      <section className="relative z-10 px-6 py-24 max-w-6xl mx-auto">
-        <div className="rounded-3xl bg-gradient-to-br from-cyan-500/10 via-nocturn/[0.04] to-transparent ring-1 ring-cyan-500/15 p-10 md:p-16 relative overflow-hidden">
-          <div className="absolute top-0 right-0 w-80 h-80 bg-cyan-500/10 rounded-full blur-[100px] pointer-events-none" />
+      <section className="relative z-10 px-6 py-20 max-w-6xl mx-auto">
+        <div className="rounded-3xl bg-card/40 ring-1 ring-white/[0.06] p-10 md:p-16 relative overflow-hidden">
+          <div className="absolute top-0 right-0 w-80 h-80 bg-nocturn/[0.08] rounded-full blur-[100px] pointer-events-none" />
 
           <div className="relative z-10 max-w-2xl">
-            <div className="flex items-center gap-2 mb-6">
-              <Users2 className="h-5 w-5 text-cyan-400" />
-              <span className="text-xs font-bold uppercase tracking-widest text-cyan-400">
-                Your Network
-              </span>
-            </div>
-            <h2 className="text-3xl md:text-4xl font-extrabold tracking-tight mb-6">
+            <div className="section-label-mono mb-6">02 / YOUR ROLODEX</div>
+            <h2 className="font-heading text-[clamp(30px,4vw,48px)] font-semibold tracking-[-0.03em] leading-[1.05] mb-6">
               Your rolodex for
               <br />
-              the nightlife industry.
+              <em className="not-italic text-nocturn-glow">
+                the nightlife industry.
+              </em>
             </h2>
             <p className="text-muted-foreground leading-relaxed mb-8 max-w-xl">
               Every connection you make on Nocturn lives in one place. See who
               you&apos;ve worked with, who you&apos;ve saved, and who&apos;s
               reached out to you — with badges showing how you know each person.
             </p>
-            <div className="flex flex-wrap gap-3">
+            <div className="flex flex-wrap gap-2">
               {[
                 { label: "Saved", icon: Heart },
                 { label: "Contacted", icon: MessageSquare },
@@ -297,9 +267,9 @@ export default function HomePage() {
               ].map(({ label, icon: Icon }) => (
                 <span
                   key={label}
-                  className="inline-flex items-center gap-1.5 rounded-full border border-cyan-500/20 bg-cyan-500/[0.06] px-3 py-1.5 text-xs font-medium text-cyan-400"
+                  className="inline-flex items-center gap-1.5 rounded-full border border-white/10 bg-white/[0.02] px-3 py-1.5 text-xs font-mono text-muted-foreground uppercase tracking-wider"
                 >
-                  <Icon className="h-3 w-3" />
+                  <Icon className="h-3 w-3 text-nocturn-glow" strokeWidth={1.5} />
                   {label}
                 </span>
               ))}
@@ -310,32 +280,35 @@ export default function HomePage() {
 
       {/* ── Features ── */}
       <section className="relative z-10 px-6 py-24 max-w-6xl mx-auto">
-        <div className="mb-16">
-          <h2 className="text-3xl md:text-4xl font-extrabold tracking-tight">
+        <div className="mb-12">
+          <div className="section-label-mono mb-5">03 / THE PLATFORM</div>
+          <h2 className="font-heading text-[clamp(30px,4vw,48px)] font-semibold tracking-[-0.03em] leading-[1.05]">
             Everything you need.
             <br />
-            <span className="text-muted-foreground">Nothing you don&apos;t.</span>
+            <span className="text-muted-foreground">
+              Nothing you don&apos;t.
+            </span>
           </h2>
-          <p className="text-sm text-muted-foreground mt-4">
+          <p className="text-sm text-muted-foreground mt-4 max-w-xl leading-relaxed">
             Use Nocturn&apos;s event tools, team chat, and AI agents whether you
             ticket here or somewhere else. No lock-in.
           </p>
         </div>
 
-        <div className="grid gap-4 sm:grid-cols-2 lg:grid-cols-4">
+        <div className="grid gap-px sm:grid-cols-2 lg:grid-cols-4 bg-white/[0.06] border border-white/[0.06] rounded-2xl overflow-hidden">
           {features.map((feature) => {
             const Icon = feature.icon;
             return (
               <div
                 key={feature.title}
-                className="group rounded-2xl bg-card/40 backdrop-blur-sm ring-1 ring-white/[0.06] p-6 transition-all duration-300 hover:ring-white/[0.1] hover:bg-card/60 hover:shadow-lg hover:shadow-nocturn/5"
+                className="group bg-background p-6 transition-colors hover:bg-white/[0.02]"
               >
-                <div
-                  className={`flex h-11 w-11 items-center justify-center rounded-xl ${feature.bg} mb-4`}
-                >
-                  <Icon className={`h-5 w-5 ${feature.color}`} />
+                <div className="flex h-9 w-9 items-center justify-center rounded-lg border border-white/10 bg-nocturn/[0.06] mb-4">
+                  <Icon className="h-4 w-4 text-nocturn-glow" strokeWidth={1.5} />
                 </div>
-                <h3 className="text-base font-bold mb-2">{feature.title}</h3>
+                <h3 className="font-heading text-base font-semibold mb-2 tracking-tight">
+                  {feature.title}
+                </h3>
                 <p className="text-sm text-muted-foreground leading-relaxed">
                   {feature.description}
                 </p>
@@ -346,41 +319,38 @@ export default function HomePage() {
       </section>
 
       {/* ── Built for Operators ── */}
-      <section className="relative z-10 px-6 py-24 max-w-6xl mx-auto">
-        <div className="rounded-3xl bg-gradient-to-br from-nocturn/10 via-nocturn/[0.04] to-transparent ring-1 ring-nocturn/15 p-10 md:p-16 relative overflow-hidden">
-          <div className="absolute top-0 right-0 w-80 h-80 bg-nocturn/10 rounded-full blur-[100px] pointer-events-none" />
+      <section className="relative z-10 px-6 py-20 max-w-6xl mx-auto">
+        <div className="rounded-3xl bg-card/40 ring-1 ring-white/[0.06] p-10 md:p-16 relative overflow-hidden">
+          <div className="absolute top-0 right-0 w-80 h-80 bg-nocturn/[0.08] rounded-full blur-[100px] pointer-events-none" />
 
           <div className="relative z-10 max-w-2xl">
-            <div className="flex items-center gap-2 mb-6">
-              <Shield className="h-5 w-5 text-nocturn-light" />
-              <span className="text-xs font-bold uppercase tracking-widest text-nocturn-light">
-                Built for Operators
-              </span>
-            </div>
-            <h2 className="text-3xl md:text-4xl font-extrabold tracking-tight mb-6">
+            <div className="section-label-mono mb-6">04 / BUILT FOR OPERATORS</div>
+            <h2 className="font-heading text-[clamp(30px,4vw,48px)] font-semibold tracking-[-0.03em] leading-[1.05] mb-6">
               Stop juggling spreadsheets,
               <br />
-              DMs, and Venmo requests.
+              <em className="not-italic text-nocturn-glow">
+                DMs, and Venmo requests.
+              </em>
             </h2>
             <p className="text-muted-foreground leading-relaxed mb-8 max-w-xl">
               Nocturn replaces 6+ tools with one platform. AI agents handle your
               marketing, finance tracking, and team coordination — so you can
               focus on creating unforgettable nights.
             </p>
-            <div className="flex flex-wrap gap-3">
+            <div className="flex flex-wrap gap-2">
               {[
-                "Stripe Payments",
-                "AI Content",
-                "Real-time Chat",
-                "Voice Recording",
-                "Venue Discovery",
-                "QR Check-in",
-                "Talent Marketplace",
+                "Stripe payments",
+                "AI content",
+                "Real-time chat",
+                "Voice recording",
+                "Venue discovery",
+                "QR check-in",
+                "Talent marketplace",
                 "Network CRM",
               ].map((tag) => (
                 <span
                   key={tag}
-                  className="rounded-full border border-nocturn/20 bg-nocturn/[0.06] px-3 py-1.5 text-xs font-medium text-nocturn-light"
+                  className="rounded-full border border-white/10 bg-white/[0.02] px-3 py-1.5 text-xs font-mono text-muted-foreground uppercase tracking-wider"
                 >
                   {tag}
                 </span>
@@ -391,30 +361,41 @@ export default function HomePage() {
       </section>
 
       {/* ── Final CTA ── */}
-      <section className="relative z-10 px-6 py-24 max-w-6xl mx-auto text-center">
-        <h2 className="text-3xl md:text-5xl font-extrabold tracking-tight mb-6">
-          Ready to level up?
+      <section className="relative z-10 px-6 py-28 max-w-6xl mx-auto text-center">
+        <h2 className="font-heading text-[clamp(36px,6vw,72px)] font-semibold tracking-[-0.035em] leading-[1.05] mb-5 max-w-3xl mx-auto">
+          Stop running a business
+          <br />
+          on <em className="not-italic text-nocturn-glow">group chats.</em>
         </h2>
-        <p className="text-muted-foreground text-lg mb-10 max-w-md mx-auto">
-          Join the operators, DJs, photographers, managers, and crews already
-          building on Nocturn.
+        <p className="text-muted-foreground text-lg mb-9 max-w-md mx-auto">
+          Free to start. Three-minute setup. Built for operators.
         </p>
-        <Link
-          href="/signup"
-          className="group inline-flex h-14 items-center justify-center rounded-xl bg-gradient-to-r from-nocturn to-nocturn-light px-10 text-lg font-bold text-white shadow-xl shadow-nocturn/25 hover:shadow-2xl hover:shadow-nocturn/30 hover:brightness-110 transition-all duration-300"
-        >
-          Get Started Free
-          <ArrowRight className="ml-2 h-5 w-5 group-hover:translate-x-1 transition-transform" />
-        </Link>
+        <div className="inline-flex flex-wrap justify-center gap-3">
+          <Link
+            href="/signup"
+            data-magnetic
+            className="inline-flex h-13 items-center justify-center rounded-xl bg-nocturn hover:bg-nocturn-light px-8 py-[14px] text-base font-medium text-white transition-colors"
+          >
+            Get started free →
+          </Link>
+          <Link
+            href="/login"
+            className="inline-flex h-13 items-center justify-center rounded-xl border border-white/10 bg-white/[0.02] px-8 py-[14px] text-base font-medium hover:bg-white/[0.05] hover:border-white/20 transition-colors"
+          >
+            Sign in
+          </Link>
+        </div>
+        <p className="mt-6 text-xs font-mono text-muted-foreground/70 uppercase tracking-[0.12em]">
+          No credit card · Free for operators
+        </p>
       </section>
 
       {/* ── Footer ── */}
       <footer className="relative z-10 border-t border-white/[0.06] px-6 py-8 max-w-6xl mx-auto">
         <div className="flex flex-col sm:flex-row items-center justify-between gap-4">
           <NocturnLogo size="sm" />
-          <p className="text-xs text-muted-foreground">
-            &copy; {new Date().getFullYear()} Nocturn Technologies. All rights
-            reserved.
+          <p className="text-xs font-mono text-muted-foreground uppercase tracking-[0.1em]">
+            © {new Date().getFullYear()} Nocturn Technologies · Built in Toronto
           </p>
         </div>
       </footer>

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -8,9 +8,9 @@
   --color-foreground: var(--foreground);
   --font-sans: var(--font-body);
   --font-heading: var(--font-heading);
-  --font-mono: var(--font-body);
+  --font-mono: var(--font-code);
   --color-nocturn: #7B2FF7;
-  --color-nocturn-light: #9D5CFF;
+  --color-nocturn-light: #A855F7;
   --color-nocturn-glow: #C084FC;
   --color-nocturn-teal: #2DD4BF;
   --color-nocturn-coral: #FB7185;
@@ -135,14 +135,14 @@
   }
   body {
     @apply bg-background text-foreground;
-    font-family: var(--font-body), "DM Sans", ui-sans-serif, system-ui, sans-serif;
+    font-family: var(--font-body), "Inter", ui-sans-serif, system-ui, sans-serif;
     /* Prevent body bounce on iOS */
     overscroll-behavior: none;
     /* Prevent text size adjust on orientation change */
     -webkit-text-size-adjust: 100%;
   }
   h1, h2, h3, h4, h5, h6 {
-    font-family: var(--font-heading), "Outfit", ui-sans-serif, sans-serif;
+    font-family: var(--font-heading), "Space Grotesk", ui-sans-serif, sans-serif;
   }
 }
 
@@ -547,6 +547,60 @@ a[role="button"]:active {
 /* Scrollbar hidden */
 .scrollbar-none::-webkit-scrollbar { display: none; }
 .scrollbar-none { -ms-overflow-style: none; scrollbar-width: none; }
+
+/* ═══════════════════════════════════════
+   MARKETING-ALIGNED CINEMATIC EFFECTS
+   Cursor spotlight + magnetic CTAs
+   ═══════════════════════════════════════ */
+.cursor-spotlight {
+  position: fixed; inset: 0; z-index: 1; pointer-events: none;
+  background: radial-gradient(circle 380px at var(--mx, 50%) var(--my, 50%), rgba(123, 47, 247, 0.10), transparent 70%);
+  mix-blend-mode: screen;
+}
+@media (max-width: 767px), (hover: none) {
+  .cursor-spotlight { display: none; }
+}
+
+/* Magnetic CTA base — JS adds transform */
+[data-magnetic] {
+  transition: transform 0.2s cubic-bezier(0.22, 1, 0.36, 1);
+  will-change: transform;
+}
+
+/* Section label (mono, numbered, with purple rule) — matches marketing */
+.section-label-mono {
+  font-family: var(--font-code), ui-monospace, monospace;
+  font-size: 12px; font-weight: 500;
+  color: var(--muted-foreground);
+  letter-spacing: 0.14em; text-transform: uppercase;
+  display: inline-flex; align-items: center; gap: 12px;
+}
+.section-label-mono::before {
+  content: ''; width: 24px; height: 1px; background: #7B2FF7;
+}
+
+/* Eyebrow pill with pulsing dot — matches marketing */
+.eyebrow-pill {
+  display: inline-flex; align-items: center; gap: 10px;
+  padding: 8px 14px;
+  border: 1px solid rgba(255, 255, 255, 0.12); border-radius: 100px;
+  font-family: var(--font-code), ui-monospace, monospace;
+  font-size: 11.5px; color: var(--muted-foreground);
+  letter-spacing: 0.08em; text-transform: uppercase;
+  background: rgba(255, 255, 255, 0.015);
+}
+.eyebrow-pill-dot {
+  width: 7px; height: 7px; border-radius: 50%;
+  background: #7B2FF7; box-shadow: 0 0 8px #7B2FF7;
+  animation: pulseGlow 2.4s ease-in-out infinite;
+}
+
+/* Stat cell for pricing/feature stats — matches marketing */
+.stat-cell-align {
+  font-family: var(--font-heading), ui-sans-serif, sans-serif;
+  font-variant-numeric: tabular-nums;
+  letter-spacing: -0.02em;
+}
 
 @media (prefers-reduced-motion: reduce) {
   *, *::before, *::after {

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,22 +1,29 @@
 import type { Metadata, Viewport } from "next";
-import { Outfit, DM_Sans } from "next/font/google";
+import { Space_Grotesk, Inter, JetBrains_Mono } from "next/font/google";
 import { Analytics } from "@vercel/analytics/next";
 import { SpeedInsights } from "@vercel/speed-insights/next";
 import { Suspense } from "react";
 import { PostHogProvider } from "@/components/posthog-provider";
 import "./globals.css";
 
-const outfit = Outfit({
+const spaceGrotesk = Space_Grotesk({
   variable: "--font-heading",
   subsets: ["latin"],
-  weight: ["500", "600", "700", "800"],
+  weight: ["400", "500", "600", "700"],
   display: "swap",
 });
 
-const dmSans = DM_Sans({
+const inter = Inter({
   variable: "--font-body",
   subsets: ["latin"],
-  weight: ["400", "500", "600", "700"],
+  weight: ["400", "500", "600"],
+  display: "swap",
+});
+
+const jetbrainsMono = JetBrains_Mono({
+  variable: "--font-code",
+  subsets: ["latin"],
+  weight: ["400", "500"],
   display: "swap",
 });
 
@@ -81,7 +88,7 @@ export default function RootLayout({
         <link rel="apple-touch-icon" href="/icons/icon-192.png" />
       </head>
       <body
-        className={`${outfit.variable} ${dmSans.variable} antialiased`}
+        className={`${spaceGrotesk.variable} ${inter.variable} ${jetbrainsMono.variable} antialiased`}
       >
         <a
           href="#main"

--- a/src/components/cinematic-effects.tsx
+++ b/src/components/cinematic-effects.tsx
@@ -1,0 +1,79 @@
+"use client";
+
+import { useEffect, useRef } from "react";
+
+/**
+ * Cursor-following spotlight + magnetic CTA effects.
+ * Matches marketing site (trynocturn.com) design language.
+ *
+ * Apply to a button by adding `data-magnetic` attribute.
+ * Spotlight is hidden on touch devices and reduced-motion.
+ */
+export function CinematicEffects() {
+  const spotlightRef = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    if (typeof window === "undefined") return;
+    if (matchMedia("(prefers-reduced-motion: reduce)").matches) return;
+
+    const spotlight = spotlightRef.current;
+
+    let mx = window.innerWidth / 2;
+    let my = window.innerHeight / 2;
+    let tx = mx;
+    let ty = my;
+    let rafId = 0;
+
+    const onMove = (e: MouseEvent) => {
+      mx = e.clientX;
+      my = e.clientY;
+    };
+    window.addEventListener("mousemove", onMove, { passive: true });
+
+    const loop = () => {
+      tx += (mx - tx) * 0.08;
+      ty += (my - ty) * 0.08;
+      if (spotlight) {
+        spotlight.style.setProperty("--mx", `${tx}px`);
+        spotlight.style.setProperty("--my", `${ty}px`);
+      }
+      rafId = requestAnimationFrame(loop);
+    };
+    loop();
+
+    // Magnetic CTAs — any element with data-magnetic attr
+    const magnets = document.querySelectorAll<HTMLElement>("[data-magnetic]");
+    const cleanups: Array<() => void> = [];
+    magnets.forEach((el) => {
+      const move = (e: MouseEvent) => {
+        const r = el.getBoundingClientRect();
+        const x = (e.clientX - r.left - r.width / 2) * 0.18;
+        const y = (e.clientY - r.top - r.height / 2) * 0.28;
+        el.style.transform = `translate(${x}px, ${y}px)`;
+      };
+      const leave = () => {
+        el.style.transform = "translate(0, 0)";
+      };
+      el.addEventListener("mousemove", move);
+      el.addEventListener("mouseleave", leave);
+      cleanups.push(() => {
+        el.removeEventListener("mousemove", move);
+        el.removeEventListener("mouseleave", leave);
+      });
+    });
+
+    return () => {
+      cancelAnimationFrame(rafId);
+      window.removeEventListener("mousemove", onMove);
+      cleanups.forEach((fn) => fn());
+    };
+  }, []);
+
+  return (
+    <div
+      ref={spotlightRef}
+      className="cursor-spotlight"
+      aria-hidden="true"
+    />
+  );
+}

--- a/src/components/nocturn-logo.tsx
+++ b/src/components/nocturn-logo.tsx
@@ -1,5 +1,3 @@
-"use client";
-
 interface NocturnLogoProps {
   size?: "sm" | "md" | "lg" | "xl";
   showText?: boolean;
@@ -8,19 +6,30 @@ interface NocturnLogoProps {
 
 export function NocturnLogo({ size = "md", showText = true, className = "" }: NocturnLogoProps) {
   const sizes = {
-    sm: { moon: "text-lg", text: "text-lg" },
-    md: { moon: "text-2xl", text: "text-2xl" },
-    lg: { moon: "text-4xl", text: "text-4xl" },
-    xl: { moon: "text-5xl", text: "text-5xl" },
+    sm: { mark: 16, text: "text-lg", gap: "gap-2" },
+    md: { mark: 20, text: "text-xl", gap: "gap-2.5" },
+    lg: { mark: 28, text: "text-3xl", gap: "gap-3" },
+    xl: { mark: 36, text: "text-4xl", gap: "gap-3" },
   };
   const s = sizes[size];
 
   return (
-    <div className={`flex items-center gap-1.5 ${className}`}>
-      <span className={s.moon}>🌙</span>
+    <div className={`inline-flex items-center ${s.gap} ${className}`}>
+      <svg
+        width={s.mark}
+        height={s.mark}
+        viewBox="0 0 32 32"
+        fill="none"
+        aria-hidden="true"
+      >
+        <circle cx="16" cy="16" r="12" fill="#7B2FF7" />
+        <circle cx="20" cy="14" r="10" fill="#09090B" />
+      </svg>
       {showText && (
-        <span className={`${s.text} font-bold tracking-tight font-heading`}>
-          nocturn.
+        <span
+          className={`${s.text} font-heading font-bold tracking-[-0.025em]`}
+        >
+          nocturn<span className="text-nocturn">.</span>
         </span>
       )}
     </div>


### PR DESCRIPTION
## Summary

Align app.trynocturn.com public landing page with the new trynocturn.com marketing design language so both surfaces feel like the same product.

## Changes

- **Fonts**: Outfit + DM Sans → **Space Grotesk + Inter + JetBrains Mono** (matches marketing site)
- **Wordmark**: emoji 🌙 → custom SVG moon-mark
- **Eyebrow pill**: mono caps with pulsing purple dot
- **Hero headline**: 2-line with `em` purple-glow highlight (no more gradient)
- **Subhead**: "Book the talent. Fill the room. Settle the night — on autopilot."
- **CTAs**: "Start free" solid purple with magnetic hover
- **Stats**: 3-cell stat-trio grid (16 roles · 100% mobile-first · 7% + $0.50)
- **Section labels**: mono numbered "01 / THE NETWORK" with purple rule
- **Icons unified**: all `text-nocturn-glow` (no more rainbow)
- **Grid treatment**: 1px-gap bordered grids (matches marketing site)
- **Cinematic effects**: cursor spotlight + magnetic CTAs via new `CinematicEffects` component
- **Purple-light token**: `#9D5CFF` → `#A855F7` (exact marketing match)

## Test plan

- [ ] Vercel preview deploys successfully
- [ ] Open preview URL on desktop — spotlight follows cursor
- [ ] "Start free" button has magnetic pull on hover
- [ ] Headline "Nocturn runs the business" shows in purple-glow
- [ ] 16 marketplace role cards render in 4-col grid with purple icons
- [ ] Mobile view at 390px — subhead no longer overflows
- [ ] Stats row shows 3 cells with mono labels + big display numbers
- [ ] "Sign In" → `/login`, "Start free" → `/signup`
- [ ] Site feels visually consistent with trynocturn.com

🤖 Generated with [Claude Code](https://claude.com/claude-code)