### PR TITLE
Fix signup guidance + stats formatting + OG/favicon alignment

### DIFF
--- a/src/app/(auth)/signup/page.tsx
+++ b/src/app/(auth)/signup/page.tsx
@@ -15,112 +15,156 @@ import {
   CardHeader,
   CardTitle,
 } from "@/components/ui/card";
-import { Users, Music, MapPin, ArrowLeft, Megaphone, Camera, Video, Speaker, Lightbulb, BadgeDollarSign, Briefcase, Plane, CalendarCheck, UserCheck, Mic, Palette, Newspaper, Loader2, PartyPopper } from "lucide-react";
+import {
+  Users,
+  Music,
+  MapPin,
+  ArrowLeft,
+  Megaphone,
+  Camera,
+  Video,
+  Speaker,
+  Lightbulb,
+  BadgeDollarSign,
+  Briefcase,
+  Plane,
+  CalendarCheck,
+  UserCheck,
+  Mic,
+  Palette,
+  Newspaper,
+  Loader2,
+  PartyPopper,
+} from "lucide-react";
 
-type UserType = "collective" | "host" | "promoter" | "artist" | "venue" | "photographer" | "videographer" | "sound_production" | "lighting_production" | "sponsor" | "artist_manager" | "tour_manager" | "booking_agent" | "event_staff" | "mc_host" | "graphic_designer" | "pr_publicist";
+type UserType =
+  | "collective"
+  | "host"
+  | "promoter"
+  | "artist"
+  | "venue"
+  | "photographer"
+  | "videographer"
+  | "sound_production"
+  | "lighting_production"
+  | "sponsor"
+  | "artist_manager"
+  | "tour_manager"
+  | "booking_agent"
+  | "event_staff"
+  | "mc_host"
+  | "graphic_designer"
+  | "pr_publicist";
 
-const USER_TYPES: Array<{ type: UserType; icon: typeof Users; label: string; description: string }> = [
+const USER_TYPES: Array<{
+  type: UserType;
+  icon: typeof Users;
+  label: string;
+  description: string;
+  tagline?: string;
+}> = [
   {
     type: "collective",
     icon: Users,
     label: "Collective",
-    description: "Run events, sell tickets, manage your crew",
+    description: "Run regular nights with a crew. Full platform: tickets, settlement, marketing, team chat, marketplace.",
+    tagline: "Most popular",
   },
   {
     type: "host",
     icon: PartyPopper,
     label: "Host",
-    description: "Throw a night, invite friends, collect RSVPs in minutes",
+    description: "Throwing a one-off. Free event, invite friends, collect RSVPs in minutes. No approval needed.",
   },
   {
     type: "promoter",
     icon: Megaphone,
     label: "Promoter",
-    description: "Sell tickets, track your sales, grow your network",
+    description: "Selling tickets under your brand. Grow your audience, track sales, get paid.",
   },
   {
     type: "artist",
     icon: Music,
     label: "Artist / DJ",
-    description: "Build your profile, get discovered, get booked",
+    description: "Build your profile, get discovered, get booked.",
   },
   {
     type: "venue",
     icon: MapPin,
     label: "Venue",
-    description: "List your space, manage bookings, connect with promoters",
+    description: "List your space, manage bookings, connect with promoters.",
   },
   {
     type: "artist_manager",
     icon: Briefcase,
     label: "Artist Manager",
-    description: "Manage bookings, deals, and career growth for artists",
+    description: "Manage bookings, deals, and career growth for artists.",
   },
   {
     type: "tour_manager",
     icon: Plane,
     label: "Tour Manager",
-    description: "Handle logistics, travel, and hospitality for touring acts",
+    description: "Handle logistics, travel, and hospitality for touring acts.",
   },
   {
     type: "booking_agent",
     icon: CalendarCheck,
     label: "Booking Agent",
-    description: "Book talent for venues, clubs, and festivals",
+    description: "Book talent for venues, clubs, and festivals.",
   },
   {
     type: "photographer",
     icon: Camera,
     label: "Photographer",
-    description: "Showcase your portfolio and get booked for events",
+    description: "Showcase your portfolio and get booked for events.",
   },
   {
     type: "videographer",
     icon: Video,
     label: "Videographer",
-    description: "Event recaps, aftermovies, and livestreams",
+    description: "Event recaps, aftermovies, and livestreams.",
   },
   {
     type: "mc_host",
     icon: Mic,
     label: "MC / Host",
-    description: "Emcee events, hype crowds, host shows",
+    description: "Emcee events, hype crowds, host shows.",
   },
   {
     type: "graphic_designer",
     icon: Palette,
     label: "Graphic Designer",
-    description: "Flyers, branding, merch, and social media assets",
+    description: "Flyers, branding, merch, and social media assets.",
   },
   {
     type: "sound_production",
     icon: Speaker,
     label: "Sound & Production",
-    description: "PA systems, sound engineering, DJ equipment",
+    description: "PA systems, sound engineering, DJ equipment.",
   },
   {
     type: "lighting_production",
     icon: Lightbulb,
     label: "Lighting & Visuals",
-    description: "Stage lighting, lasers, LED walls, VJ",
+    description: "Stage lighting, lasers, LED walls, VJ.",
   },
   {
     type: "event_staff",
     icon: UserCheck,
     label: "Event Staff",
-    description: "Bartenders, security, door staff, barbacks",
+    description: "Bartenders, security, door staff, barbacks.",
   },
   {
     type: "pr_publicist",
     icon: Newspaper,
     label: "PR / Publicist",
-    description: "Press coverage, media outreach, social strategy",
+    description: "Press coverage, media outreach, social strategy.",
   },
   {
     type: "sponsor",
     icon: BadgeDollarSign,
     label: "Sponsor / Brand",
-    description: "Connect with events and collectives for partnerships",
+    description: "Connect with events and collectives for partnerships.",
   },
 ];
 
@@ -147,8 +191,6 @@ export default function SignupPage() {
       return;
     }
 
-    // Route based on user type — only collectives and promoters need manual approval.
-    // Hosts are instant-access (the whole value prop is "throw a night in minutes").
     if (userType === "collective" || userType === "promoter") {
       router.push("/pending-approval");
     } else {
@@ -157,7 +199,6 @@ export default function SignupPage() {
     router.refresh();
   }
 
-  // Split into primary types (full cards) and marketplace types (compact grid)
   const primaryTypes = USER_TYPES.filter((t) =>
     ["collective", "host", "promoter"].includes(t.type)
   );
@@ -168,69 +209,78 @@ export default function SignupPage() {
   if (step === "type") {
     return (
       <Card>
-        <CardHeader className="text-center">
-          <CardTitle className="text-2xl">Join Nocturn</CardTitle>
-          <CardDescription>How do you want to use the platform?</CardDescription>
+        <CardHeader className="text-center pb-4">
+          <CardTitle className="text-xl">Join Nocturn</CardTitle>
+          <CardDescription className="text-sm">
+            Pick what fits you best — you can add more later.
+          </CardDescription>
         </CardHeader>
         <CardContent className="space-y-5">
-          {/* Primary: Collective & Promoter — full-width cards */}
-          <div className="space-y-3">
-            {primaryTypes.map(({ type, icon: Icon, label, description }) => (
-              <button
-                key={type}
-                onClick={() => {
-                  setUserType(type);
-                  setStep("form");
-                }}
-                className={`w-full flex items-center gap-4 rounded-xl border p-4 text-left transition-all hover:border-nocturn/50 hover:bg-nocturn/5 active:scale-[0.98] min-h-[56px] ${
-                  userType === type ? "border-nocturn bg-nocturn/10" : "border-border"
-                }`}
-              >
-                <div className="flex h-12 w-12 items-center justify-center rounded-xl bg-nocturn/20 shrink-0">
-                  <Icon className="h-6 w-6 text-nocturn" />
-                </div>
-                <div>
-                  <p className="font-semibold text-foreground">{label}</p>
-                  <p className="text-sm text-muted-foreground">{description}</p>
-                </div>
-              </button>
-            ))}
+          {/* Primary: Event operators */}
+          <div>
+            <div className="section-label-mono mb-3 text-[11px]">
+              01 / I THROW EVENTS
+            </div>
+            <div className="space-y-2">
+              {primaryTypes.map(({ type, icon: Icon, label, description, tagline }) => (
+                <button
+                  key={type}
+                  onClick={() => {
+                    setUserType(type);
+                    setStep("form");
+                  }}
+                  className="group w-full flex items-start gap-3 rounded-xl border border-border p-3.5 text-left transition-all hover:border-nocturn/40 hover:bg-nocturn/5 active:scale-[0.98] min-h-[56px]"
+                >
+                  <div className="flex h-9 w-9 items-center justify-center rounded-lg border border-white/10 bg-nocturn/[0.08] shrink-0 mt-0.5">
+                    <Icon className="h-4 w-4 text-nocturn-glow" strokeWidth={1.5} />
+                  </div>
+                  <div className="flex-1 min-w-0">
+                    <div className="flex items-center gap-2 mb-0.5">
+                      <p className="font-semibold text-sm text-foreground">{label}</p>
+                      {tagline && (
+                        <span className="text-[10px] font-mono font-medium uppercase tracking-wider text-nocturn-glow bg-nocturn/10 border border-nocturn/20 rounded-full px-2 py-0.5">
+                          {tagline}
+                        </span>
+                      )}
+                    </div>
+                    <p className="text-xs text-muted-foreground leading-relaxed">{description}</p>
+                  </div>
+                </button>
+              ))}
+            </div>
           </div>
 
-          {/* Divider */}
-          <div className="flex items-center gap-3">
-            <div className="h-px flex-1 bg-border" />
-            <span className="text-xs text-muted-foreground uppercase tracking-wider">
-              List yourself on the marketplace
-            </span>
-            <div className="h-px flex-1 bg-border" />
-          </div>
-
-          {/* Marketplace types — compact 2-column grid */}
-          <div className="grid grid-cols-2 gap-2">
-            {marketplaceTypes.map(({ type, icon: Icon, label }) => (
-              <button
-                key={type}
-                onClick={() => {
-                  setUserType(type);
-                  setStep("form");
-                }}
-                className={`flex items-center gap-3 rounded-xl border p-3 text-left transition-all hover:border-nocturn/50 hover:bg-nocturn/5 active:scale-[0.98] min-h-[56px] ${
-                  userType === type ? "border-nocturn bg-nocturn/10" : "border-border"
-                }`}
-              >
-                <div className="flex h-9 w-9 items-center justify-center rounded-lg bg-nocturn/20 shrink-0">
-                  <Icon className="h-4 w-4 text-nocturn" />
-                </div>
-                <p className="font-medium text-sm text-white leading-tight">{label}</p>
-              </button>
-            ))}
+          {/* Marketplace section */}
+          <div>
+            <div className="section-label-mono mb-2 text-[11px]">
+              02 / I WORK AT EVENTS
+            </div>
+            <p className="text-xs text-muted-foreground mb-3 leading-relaxed">
+              List yourself on the Discover marketplace. Get found by collectives, promoters, and venues.
+            </p>
+            <div className="grid grid-cols-2 gap-2">
+              {marketplaceTypes.map(({ type, icon: Icon, label }) => (
+                <button
+                  key={type}
+                  onClick={() => {
+                    setUserType(type);
+                    setStep("form");
+                  }}
+                  className="flex items-center gap-2.5 rounded-lg border border-border p-2.5 text-left transition-all hover:border-nocturn/40 hover:bg-nocturn/5 active:scale-[0.98] min-h-[44px]"
+                >
+                  <div className="flex h-7 w-7 items-center justify-center rounded-md border border-white/10 bg-nocturn/[0.08] shrink-0">
+                    <Icon className="h-3.5 w-3.5 text-nocturn-glow" strokeWidth={1.5} />
+                  </div>
+                  <p className="font-medium text-xs text-foreground leading-tight truncate">{label}</p>
+                </button>
+              ))}
+            </div>
           </div>
         </CardContent>
-        <CardFooter className="justify-center">
+        <CardFooter className="justify-center pt-4">
           <p className="text-sm text-muted-foreground">
             Already have an account?{" "}
-            <Link href="/login" className="text-nocturn hover:underline">
+            <Link href="/login" className="text-nocturn-glow hover:underline">
               Sign in
             </Link>
           </p>
@@ -246,18 +296,18 @@ export default function SignupPage() {
       <CardHeader>
         <button
           onClick={() => setStep("type")}
-          className="flex items-center gap-1.5 text-sm text-muted-foreground hover:text-white transition-colors mb-2 min-h-[44px]"
+          className="flex items-center gap-1.5 text-xs font-mono uppercase tracking-wider text-muted-foreground hover:text-foreground transition-colors mb-3 min-h-[44px]"
         >
           <ArrowLeft className="h-3.5 w-3.5" />
           Change type
         </button>
         <div className="flex items-center gap-3">
-          <div className="flex h-10 w-10 items-center justify-center rounded-xl bg-nocturn/20">
-            <selectedType.icon className="h-5 w-5 text-nocturn" />
+          <div className="flex h-10 w-10 items-center justify-center rounded-lg border border-white/10 bg-nocturn/[0.08]">
+            <selectedType.icon className="h-4 w-4 text-nocturn-glow" strokeWidth={1.5} />
           </div>
           <div>
-            <CardTitle>{selectedType.label}</CardTitle>
-            <CardDescription>{selectedType.description}</CardDescription>
+            <CardTitle className="text-lg">{selectedType.label}</CardTitle>
+            <CardDescription className="text-xs leading-relaxed">{selectedType.description}</CardDescription>
           </div>
         </div>
       </CardHeader>
@@ -322,7 +372,7 @@ export default function SignupPage() {
       <CardFooter className="justify-center">
         <p className="text-sm text-muted-foreground">
           Already have an account?{" "}
-          <Link href="/login" className="text-nocturn hover:underline">
+          <Link href="/login" className="text-nocturn-glow hover:underline">
             Sign in
           </Link>
         </p>

--- a/src/app/(public)/page.tsx
+++ b/src/app/(public)/page.tsx
@@ -107,7 +107,7 @@ const marketplaceRoles = [
 const stats = [
   { value: "16", label: "Professional roles" },
   { value: "100%", label: "Mobile-first" },
-  { value: "7% + $0.50", label: "Per ticket · buyer pays" },
+  { value: "7%", label: "+ $0.50 · buyer pays fee" },
 ];
 
 export default function HomePage() {
@@ -192,7 +192,7 @@ export default function HomePage() {
                 key={stat.label}
                 className="bg-background px-6 py-7 flex flex-col gap-2 transition-colors hover:bg-white/[0.02]"
               >
-                <p className="stat-cell-align text-[clamp(32px,4vw,44px)] font-semibold text-nocturn-glow leading-none">
+                <p className="stat-cell-align text-[clamp(32px,4vw,44px)] font-semibold text-nocturn-glow leading-none whitespace-nowrap">
                   {stat.value}
                 </p>
                 <p className="text-[11px] font-mono text-muted-foreground uppercase tracking-[0.14em]">

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -39,7 +39,7 @@ export const metadata: Metadata = {
   description:
     "You run the night. Nocturn runs the business.",
   icons: {
-    icon: "data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 100 100'><text y='.9em' font-size='90'>🌙</text></svg>",
+    icon: "data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 32 32'><circle cx='16' cy='16' r='12' fill='%237B2FF7'/><circle cx='20' cy='14' r='10' fill='%2309090B'/></svg>",
   },
   openGraph: {
     title: "Nocturn — AI for Music Collectives and Promoters",

--- a/src/app/og-image/route.tsx
+++ b/src/app/og-image/route.tsx
@@ -1,23 +1,177 @@
-import { ImageResponse } from 'next/og';
+import { ImageResponse } from "next/og";
 
-export const runtime = 'edge';
+export const runtime = "edge";
 
 export async function GET() {
   return new ImageResponse(
     (
-      <div style={{
-        width: '100%', height: '100%', display: 'flex', flexDirection: 'column',
-        alignItems: 'center', justifyContent: 'center',
-        background: '#09090B', color: 'white', fontFamily: 'sans-serif'
-      }}>
-        <div style={{ display: 'flex', alignItems: 'center', gap: 12, marginBottom: 20 }}>
-          <span style={{ fontSize: 80 }}>🌙</span>
-          <span style={{ fontSize: 72, fontWeight: 800, color: 'white' }}>
-            nocturn.
-          </span>
-        </div>
-        <div style={{ fontSize: 28, color: '#a1a1aa' }}>
-          AI for Music Collectives and Promoters
+      <div
+        style={{
+          width: "100%",
+          height: "100%",
+          display: "flex",
+          background: "#09090B",
+          color: "#FAFAFA",
+          position: "relative",
+          overflow: "hidden",
+        }}
+      >
+        {/* Ambient purple glow — top left */}
+        <div
+          style={{
+            position: "absolute",
+            top: -200,
+            left: -150,
+            width: 800,
+            height: 800,
+            borderRadius: "50%",
+            background:
+              "radial-gradient(circle, rgba(123,47,247,0.22) 0%, transparent 65%)",
+          }}
+        />
+        {/* Ambient purple glow — bottom right */}
+        <div
+          style={{
+            position: "absolute",
+            bottom: -250,
+            right: -150,
+            width: 700,
+            height: 700,
+            borderRadius: "50%",
+            background:
+              "radial-gradient(circle, rgba(168,85,247,0.18) 0%, transparent 65%)",
+          }}
+        />
+
+        {/* Content container */}
+        <div
+          style={{
+            position: "absolute",
+            top: 72,
+            left: 88,
+            right: 88,
+            bottom: 72,
+            display: "flex",
+            flexDirection: "column",
+            justifyContent: "space-between",
+          }}
+        >
+          {/* Top row: wordmark + eyebrow pill */}
+          <div
+            style={{
+              display: "flex",
+              justifyContent: "space-between",
+              alignItems: "center",
+              width: "100%",
+            }}
+          >
+            {/* Wordmark */}
+            <div style={{ display: "flex", alignItems: "center", gap: 14 }}>
+              <svg width="36" height="36" viewBox="0 0 32 32" fill="none">
+                <circle cx="16" cy="16" r="12" fill="#7B2FF7" />
+                <circle cx="20" cy="14" r="10" fill="#09090B" />
+              </svg>
+              <div
+                style={{
+                  fontSize: 40,
+                  fontWeight: 700,
+                  letterSpacing: "-0.025em",
+                  color: "#FAFAFA",
+                  display: "flex",
+                }}
+              >
+                nocturn<span style={{ color: "#7B2FF7" }}>.</span>
+              </div>
+            </div>
+
+            {/* Eyebrow pill */}
+            <div
+              style={{
+                display: "flex",
+                alignItems: "center",
+                gap: 10,
+                padding: "9px 16px",
+                border: "1px solid rgba(255,255,255,0.14)",
+                borderRadius: 100,
+                fontSize: 13,
+                color: "#A1A1AA",
+                letterSpacing: "0.08em",
+                background: "rgba(123,47,247,0.05)",
+              }}
+            >
+              <div
+                style={{
+                  width: 8,
+                  height: 8,
+                  borderRadius: "50%",
+                  background: "#C084FC",
+                }}
+              />
+              THE AGENTIC WORK OS · NIGHTLIFE
+            </div>
+          </div>
+
+          {/* Main headline */}
+          <div style={{ display: "flex", flexDirection: "column" }}>
+            <div
+              style={{
+                fontSize: 96,
+                fontWeight: 600,
+                lineHeight: 0.96,
+                letterSpacing: "-0.035em",
+                color: "#FAFAFA",
+                display: "flex",
+                flexDirection: "column",
+              }}
+            >
+              <div>You run the night.</div>
+              <div style={{ color: "#C084FC" }}>
+                Nocturn runs the business.
+              </div>
+            </div>
+            <div
+              style={{
+                fontSize: 20,
+                color: "#FAFAFA",
+                marginTop: 28,
+                letterSpacing: "0.01em",
+                display: "flex",
+              }}
+            >
+              Book the talent. Fill the room. Settle the night —{" "}
+              <span style={{ color: "#C084FC", marginLeft: 8 }}>
+                on autopilot.
+              </span>
+            </div>
+          </div>
+
+          {/* Bottom row */}
+          <div
+            style={{
+              display: "flex",
+              justifyContent: "space-between",
+              alignItems: "center",
+              fontSize: 14,
+              color: "#52525B",
+              letterSpacing: "0.14em",
+              textTransform: "uppercase",
+            }}
+          >
+            <div style={{ display: "flex", alignItems: "center" }}>
+              <div
+                style={{
+                  width: 40,
+                  height: 1,
+                  background: "#7B2FF7",
+                  marginRight: 14,
+                }}
+              />
+              BUILT FOR OPERATORS · FREE TO START
+            </div>
+            <div style={{ color: "#C084FC", fontWeight: 500 }}>
+              APP.TRYNOCTURN.COM
+            </div>
+          </div>
         </div>
       </div>
     ),


### PR DESCRIPTION
## Summary

Follow-up polish to PR #79:

1. **Signup page** — restructured into 2 clear paths ("I THROW EVENTS" vs "I WORK AT EVENTS"), added "Most popular" tag on Collective, tightened sizing so all options fit without feeling zoomed, expanded descriptions so users can self-select confidently
2. **Stats formatting** — split "7% + $0.50" into `7%` value + `+ $0.50 · buyer pays fee` label so it stops wrapping on narrow viewports
3. **Favicon** — swapped emoji SVG for custom moon-mark SVG (matches marketing)
4. **OG image route** (`/og-image`) — full redesign matching marketing iMessage preview: SVG wordmark, eyebrow pill "THE AGENTIC WORK OS · NIGHTLIFE", purple-glow headline, "Book the talent…" subtitle, ambient glows

## Test plan

- [ ] Click "Start free" on app landing — signup page fits on one screen without zoom
- [ ] Collective shows "Most popular" badge
- [ ] Stats row on landing shows `7%` clean (no wrapping)
- [ ] Browser tab favicon shows new moon SVG (not emoji)
- [ ] `/og-image` route renders new design (share app.trynocturn.com in iMessage to verify)

🤖 Generated with [Claude Code](https://claude.com/claude-code)