### PR TITLE
Friendlier copy: drop 'Agentic Work OS' jargon

### DIFF
--- a/src/app/(public)/page.tsx
+++ b/src/app/(public)/page.tsx
@@ -6,7 +6,7 @@ import { CinematicEffects } from "@/components/cinematic-effects";
 export const metadata: Metadata = {
   title: "Nocturn — You run the night. Nocturn runs the business.",
   description:
-    "The Agentic Work OS for nightlife. Book the talent. Fill the room. Settle the night — on autopilot.",
+    "Run your nights from one place. Events, tickets, finance, team chat, and a talent marketplace — for collectives, promoters, and venues.",
 };
 import {
   Calendar,
@@ -148,7 +148,7 @@ export default function HomePage() {
         <div className="max-w-3xl">
           <div className="eyebrow-pill mb-8">
             <span className="eyebrow-pill-dot" />
-            THE AGENTIC WORK OS · NIGHTLIFE
+            BUILT FOR COLLECTIVES · PROMOTERS · VENUES
           </div>
 
           <h1 className="font-heading text-[clamp(44px,7vw,80px)] font-semibold tracking-[-0.035em] leading-[0.98]">
@@ -160,8 +160,7 @@ export default function HomePage() {
           </h1>
 
           <p className="mt-7 text-lg md:text-xl text-muted-foreground max-w-xl leading-[1.5]">
-            The Agentic Work OS for nightlife. Book the talent. Fill the room.
-            Settle the night —{" "}
+            Book the talent. Fill the room. Settle the night —{" "}
             <span className="text-nocturn-glow">on autopilot.</span>
           </p>
 

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -35,15 +35,16 @@ export const viewport: Viewport = {
 };
 
 export const metadata: Metadata = {
-  title: "Nocturn — AI for Music Collectives and Promoters",
+  title: "Nocturn — You run the night. Nocturn runs the business.",
   description:
-    "You run the night. Nocturn runs the business.",
+    "Run your nights from one place. Events, tickets, finance, team chat, and a talent marketplace — for collectives, promoters, and venues.",
   icons: {
     icon: "data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 32 32'><circle cx='16' cy='16' r='12' fill='%237B2FF7'/><circle cx='20' cy='14' r='10' fill='%2309090B'/></svg>",
   },
   openGraph: {
-    title: "Nocturn — AI for Music Collectives and Promoters",
-    description: "You run the night. Nocturn runs the business.",
+    title: "Nocturn — You run the night. Nocturn runs the business.",
+    description:
+      "Run your nights from one place. Events, tickets, finance, team chat, and a talent marketplace — for collectives, promoters, and venues.",
     url: "https://app.trynocturn.com",
     siteName: "Nocturn",
     images: [
@@ -51,15 +52,16 @@ export const metadata: Metadata = {
         url: "https://app.trynocturn.com/og-image",
         width: 1200,
         height: 630,
-        alt: "Nocturn — AI for Music Collectives and Promoters",
+        alt: "Nocturn — You run the night. Nocturn runs the business.",
       },
     ],
     type: "website",
   },
   twitter: {
     card: "summary_large_image",
-    title: "Nocturn — AI for Music Collectives and Promoters",
-    description: "You run the night. Nocturn runs the business.",
+    title: "Nocturn — You run the night. Nocturn runs the business.",
+    description:
+      "Run your nights from one place. Events, tickets, finance, team chat, and a talent marketplace — for collectives, promoters, and venues.",
     images: ["https://app.trynocturn.com/og-image"],
   },
 };

--- a/src/app/og-image/route.tsx
+++ b/src/app/og-image/route.tsx
@@ -107,7 +107,7 @@ export async function GET() {
                   background: "#C084FC",
                 }}
               />
-              THE AGENTIC WORK OS · NIGHTLIFE
+              BUILT FOR COLLECTIVES · PROMOTERS · VENUES
             </div>
           </div>
 


### PR DESCRIPTION
App-side copy update to match trynocturn-site PR #3. Replaces jargony 'Agentic Work OS' phrasing with specific, audience-clear language in metadata descriptions, hero eyebrow pill, and OG image.