### PR TITLE
fix(qa): provision event-assets storage bucket + accept any Supabase host (NOC-22)

### DIFF
--- a/next.config.ts
+++ b/next.config.ts
@@ -50,7 +50,7 @@ const nextConfig: NextConfig = {
     remotePatterns: [
       {
         protocol: "https",
-        hostname: "zvmslijvdkcnkrjjgaie.supabase.co",
+        hostname: "**.supabase.co",
         pathname: "/storage/**",
       },
       {

--- a/supabase/migrations/20260421000002_event_assets_bucket.sql
+++ b/supabase/migrations/20260421000002_event_assets_bucket.sql
@@ -1,0 +1,30 @@
+-- QA (and any future Supabase branch / prod-rebuild) needs the
+-- `event-assets` Storage bucket for flyer uploads. Supabase's post-#93
+-- bootstrap didn't provision it, so `src/app/actions/ai-theme.ts`
+-- `admin.storage.from("event-assets").upload(...)` was returning
+-- "Bucket not found" and the UI surfaced that as a generic upload error.
+--
+-- Idempotent: ON CONFLICT lets this run on every fresh environment
+-- without re-erroring. Applied to QA via Supabase MCP while debugging.
+
+INSERT INTO storage.buckets (id, name, public, file_size_limit, allowed_mime_types)
+VALUES (
+  'event-assets',
+  'event-assets',
+  true,
+  10485760,  -- 10 MB; matches MAX_FILE_BYTES in ai-theme.ts
+  ARRAY['image/jpeg','image/png','image/webp','image/gif','image/svg+xml','image/avif']
+)
+ON CONFLICT (id) DO UPDATE SET
+  public = EXCLUDED.public,
+  file_size_limit = EXCLUDED.file_size_limit,
+  allowed_mime_types = EXCLUDED.allowed_mime_types;
+
+-- Public read policy — flyers render on the unauthenticated public event
+-- page (`/e/{slug}/{eventSlug}`), so attendees need to see the images
+-- without a session. Writes go through the service role (admin client)
+-- in server actions, so no authenticated-insert policy is needed.
+DROP POLICY IF EXISTS "event-assets public read" ON storage.objects;
+CREATE POLICY "event-assets public read" ON storage.objects
+  FOR SELECT TO public
+  USING (bucket_id = 'event-assets');

--- a/supabase/migrations/_rollback_20260421000002_event_assets_bucket.sql
+++ b/supabase/migrations/_rollback_20260421000002_event_assets_bucket.sql
@@ -1,0 +1,20 @@
+-- Rollback for 20260421000002_event_assets_bucket.sql
+-- Per docs/DB_Data_Governance.md § 8: every destructive migration ships
+-- a rollback. The forward migration is additive (creates a bucket + a
+-- policy), so this rollback is straightforward — but read the warning.
+--
+-- WARNING: deleting a Storage bucket via SQL is BLOCKED by Supabase
+-- (storage.protect_delete trigger). The bucket itself must be removed
+-- via the Supabase Dashboard (Storage → event-assets → Delete bucket)
+-- or via the Storage API. This rollback drops only the read policy
+-- and leaves the bucket inert — Andrew can finish the cleanup in the
+-- dashboard if a full revert is needed.
+
+-- 1. Drop the public-read policy on event-assets objects.
+DROP POLICY IF EXISTS "event-assets public read" ON storage.objects;
+
+-- 2. (Manual) To remove the bucket itself:
+--      Supabase Dashboard → Storage → event-assets → Delete bucket
+--    Or via the Storage REST API:
+--      DELETE /storage/v1/bucket/event-assets
+--    Direct DELETE FROM storage.buckets is blocked by storage.protect_delete().


### PR DESCRIPTION
Closes [NOC-22](https://linear.app/nocturn/issue/NOC-22/qa-flyer-upload-fails-event-assets-bucket-missing-nextimage-hostname).

Flyer upload was returning \"Failed to upload flyer\" because QA Supabase had **zero storage buckets**. Vercel runtime log: \`[ai-theme] upload error: Bucket not found\`.

## Migration — \`20260421000002_event_assets_bucket.sql\`

Idempotent bucket creation so every Supabase branch (QA, future previews, prod-rebuild) gets a matching \`event-assets\`:
- Public, 10 MB limit.
- MIME whitelist matches \`ai-theme.ts:ALLOWED_MIME_TYPES\`.
- Public-read RLS policy so flyers render on the unauthenticated public event page.
- No authenticated-insert policy — uploads go via service role.

Already applied to QA via Supabase MCP while debugging.

## Code

\`next.config.ts\` — \`images.remotePatterns\` widened from \`zvmslijvdkcnkrjjgaie.supabase.co\` to \`**.supabase.co\` so any Supabase project works for \`next/image\` without a per-branch config change.

## Test plan

- [ ] \`/dashboard/events/{id}/design\` → upload a JPG → succeeds.
- [ ] Flyer preview renders in the design page.
- [ ] Public event page shows the flyer via \`next/image\` with no hostname warning.
- [ ] Re-upload overwrites cleanly.
- [ ] \`npm run build\` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)