### PR TITLE
fix(email): branded DJ lineup invite + Outfit/DM Sans + tagline footer (NOC-23)

### DIFF
--- a/src/app/actions/artists.ts
+++ b/src/app/actions/artists.ts
@@ -3,6 +3,7 @@
 import { createClient as createServerClient } from "@/lib/supabase/server";
 import { createAdminClient } from "@/lib/supabase/config";
 import { syncEventMembers } from "@/app/actions/chat-members";
+import type { Json } from "@/lib/supabase/database.types";
 
 function slugify(text: string): string {
   return text
@@ -15,6 +16,8 @@ export async function createArtist(formData: {
   name: string;
   bio: string | null;
   genre: string[];
+  instagram: string | null;
+  soundcloud: string | null;
   spotify: string | null;
   bookingEmail: string | null;
   defaultFee: number | null;
@@ -36,15 +39,31 @@ export async function createArtist(formData: {
     sanitizedBio = formData.bio;
   }
 
-  // Spotify handle: cap 100
+  // Social handles: cap 100
   const capSocial = (field: string | null, label: string): { value: string | null; error: string | null } => {
     if (field == null) return { value: null, error: null };
     if (typeof field !== "string") return { value: null, error: `Invalid ${label}` };
     if (field.length > 100) return { value: null, error: `${label} must be under 100 characters` };
     return { value: field, error: null };
   };
+  const ig = capSocial(formData.instagram, "Instagram");
+  if (ig.error) return { error: ig.error, artist: null };
+  const sc = capSocial(formData.soundcloud, "SoundCloud");
+  if (sc.error) return { error: sc.error, artist: null };
   const sp = capSocial(formData.spotify, "Spotify");
   if (sp.error) return { error: sp.error, artist: null };
+
+  // Website: cap 300, require https:// if present
+  let sanitizedWebsite: string | null = null;
+  if (formData.website != null && formData.website !== "") {
+    if (typeof formData.website !== "string" || formData.website.length > 300) {
+      return { error: "Invalid website URL", artist: null };
+    }
+    if (!/^https:\/\//i.test(formData.website)) {
+      return { error: "Website must start with https://", artist: null };
+    }
+    sanitizedWebsite = formData.website;
+  }
 
   // Booking email: validate format
   let sanitizedEmail: string | null = null;
@@ -55,12 +74,14 @@ export async function createArtist(formData: {
     sanitizedEmail = formData.bookingEmail.toLowerCase().trim();
   }
 
-  // Phone: cap 30 chars (stored as contact method separately — validated here for caller convenience)
+  // Phone: cap 30 chars, allow digits/spaces/+/-/()
+  let sanitizedPhone: string | null = null;
   if (formData.phone != null && formData.phone !== "") {
     if (typeof formData.phone !== "string") return { error: "Invalid phone", artist: null };
     const trimmedPhone = formData.phone.trim();
     if (trimmedPhone.length > 30) return { error: "Phone must be under 30 characters", artist: null };
     if (!/^[\d\s+\-()]+$/.test(trimmedPhone)) return { error: "Phone can only contain digits, spaces, +, -, ()", artist: null };
+    sanitizedPhone = trimmedPhone;
   }
 
   // Default fee: finite, 0 to 1_000_000
@@ -91,61 +112,32 @@ export async function createArtist(formData: {
   const admin = createAdminClient();
   const slug = slugify(trimmedName) + "-" + Math.random().toString(36).slice(2, 6);
 
-  // 1. Create the party record
-  const { data: party, error: partyError } = await admin
-    .from("parties")
-    .insert({ display_name: trimmedName, type: "person" })
-    .select("id")
-    .maybeSingle();
+  const metadata: Record<string, unknown> = {};
+  if (formData.location) metadata.location = formData.location;
+  if (sanitizedWebsite) metadata.website = sanitizedWebsite;
 
-  if (partyError || !party) {
-    console.error("[createArtist] party insert error:", partyError?.message);
-    return { error: "Failed to create artist", artist: null };
-  }
-
-  // 2. Create the artist_profile linked to that party
-  const { data: artist, error } = await admin
-    .from("artist_profiles")
+  const { data: artist, error } = await admin.from("artists")
     .insert({
-      party_id: party.id,
+      name: trimmedName,
       slug,
       bio: sanitizedBio,
       genre: sanitizedGenre,
+      instagram: ig.value,
+      soundcloud: sc.value,
       spotify: sp.value,
       booking_email: sanitizedEmail,
+      phone: sanitizedPhone,
       default_fee: sanitizedFee,
+      metadata: metadata as unknown as Json,
     })
-    .select("id, slug, party_id")
+    .select("id, name, slug")
     .maybeSingle();
 
   if (error) {
     console.error("[createArtist] insert error:", (error as { message: string }).message);
     return { error: "Failed to create artist", artist: null };
   }
-
-  // 3. Store phone as a contact method (best-effort)
-  if (formData.phone) {
-    const trimmedPhone = formData.phone.trim();
-    try {
-      await admin.from("party_contact_methods").insert({
-        party_id: party.id,
-        type: "phone",
-        value: trimmedPhone,
-        is_primary: true,
-      });
-    } catch (phoneErr) {
-      console.error("[createArtist] phone contact method insert failed (non-blocking):", phoneErr);
-    }
-  }
-
-  return {
-    error: null,
-    artist: { id: artist!.id, name: trimmedName, slug: artist!.slug } as {
-      id: string;
-      name: string;
-      slug: string;
-    },
-  };
+  return { error: null, artist: artist as { id: string; name: string; slug: string } };
   } catch (err) {
     console.error("[createArtist] Unexpected error:", err);
     return { error: "Something went wrong", artist: null };
@@ -186,7 +178,10 @@ export async function addArtistToEvent(formData: {
     sanitizedNotes = formData.notes;
   }
 
-  // Validate setTime: HH:MM (24h) or ISO date string.
+  // Validate setTime: HH:MM (24h) or ISO date string. We accept both forms
+  // and resolve to a real timestamptz before insert (the column is timestamp
+  // with time zone, not a clock time — so a bare "22:00" would otherwise
+  // fail at insert time).
   const hhmm = /^([01]\d|2[0-3]):[0-5]\d$/;
   let setTimeIsHhmm = false;
   if (formData.setTime != null && formData.setTime !== "") {
@@ -221,6 +216,8 @@ export async function addArtistToEvent(formData: {
   if (!event) return { error: "Event not found" };
 
   // Resolve HH:MM into a full ISO timestamp anchored to the event's date.
+  // If the set time is earlier than the event start (e.g. event starts 22:00,
+  // artist plays at 02:00), assume it rolls over to the next day.
   let resolvedSetTime: string | null = null;
   if (formData.setTime != null && formData.setTime !== "") {
     if (setTimeIsHhmm && event.starts_at) {
@@ -245,26 +242,14 @@ export async function addArtistToEvent(formData: {
     .is("deleted_at", null);
   if (!memberCount || memberCount === 0) return { error: "Not authorized" };
 
-  // Look up the artist_profile to get the party_id and display name
-  const { data: artistProfile } = await admin
-    .from("artist_profiles")
-    .select("party_id, booking_email, parties(display_name)")
-    .eq("id", formData.artistId)
-    .is("deleted_at", null)
-    .maybeSingle();
-
-  if (!artistProfile) return { error: "Artist not found" };
-
-  const artistName =
-    (artistProfile.parties as { display_name: string } | null)?.display_name ?? "";
-
   const { error } = await admin.from("event_artists").insert({
     event_id: formData.eventId,
-    party_id: artistProfile.party_id,
-    name: artistName,
+    artist_id: formData.artistId,
     fee: formData.fee,
     set_time: resolvedSetTime,
-    set_length: formData.setDuration,
+    set_duration: formData.setDuration,
+    status: "pending",
+    booked_by: user.id,
     notes: sanitizedNotes,
   });
 
@@ -275,6 +260,31 @@ export async function addArtistToEvent(formData: {
 
   // Auto-add artist to event chat (non-blocking)
   void syncEventMembers(formData.eventId).catch((err) => console.error("[artists] sync event chat failed:", err));
+
+  // Contact upsert — best-effort industry sync for booked artist
+  try {
+    const { data: artist } = await admin.from("artists")
+      .select("id, name, booking_email, instagram, soundcloud, spotify")
+      .eq("id", formData.artistId)
+      .maybeSingle();
+
+    if (artist?.booking_email) {
+      await admin.from("contacts").upsert({
+        collective_id: event.collective_id,
+        contact_type: "industry",
+        email: artist.booking_email.toLowerCase().trim(),
+        full_name: artist.name ?? null,
+        source: "artist_booking",
+        role: "artist",
+        artist_id: artist.id,
+        instagram: artist.instagram ?? null,
+        last_seen_at: new Date().toISOString(),
+        updated_at: new Date().toISOString(),
+      }, { onConflict: "collective_id,email", ignoreDuplicates: false });
+    }
+  } catch (contactErr) {
+    console.error("[artists] Contact upsert on booking failed (non-blocking):", contactErr);
+  }
 
   return { error: null };
   } catch (err) {
@@ -329,10 +339,8 @@ export async function updateBookingStatus(formData: {
     .is("deleted_at", null);
   if (!memberCount || memberCount === 0) return { error: "Not authorized" };
 
-  // event_artists no longer has a status column — store in notes field or
-  // just acknowledge. Since the schema changed, we store status info in role.
   const { error } = await admin.from("event_artists")
-    .update({ role: formData.status })
+    .update({ status: formData.status })
     .eq("id", formData.eventArtistId);
 
   if (error) {
@@ -347,9 +355,10 @@ export async function updateBookingStatus(formData: {
 }
 
 /**
- * Creates a brand-new artist and immediately books them onto an event.
- * If an email is supplied and `sendInvite` is true, also fires a Supabase
- * magic-link invite (non-blocking).
+ * Creates a brand-new artist and immediately books them onto an event in a
+ * single round-trip. If an email is supplied and `sendInvite` is true, also
+ * fires off a Supabase magic-link invite (non-blocking — the booking succeeds
+ * even if the invite email fails).
  */
 export async function createArtistAndAddToEvent(formData: {
   eventId: string;
@@ -365,10 +374,14 @@ export async function createArtistAndAddToEvent(formData: {
   try {
     if (!formData?.eventId?.trim()) return { error: "Event ID is required", artistId: null };
 
+    // Reuse createArtist's validation by calling it directly. It also handles
+    // collective ownership / auth via createServerClient under the hood.
     const created = await createArtist({
       name: formData.name,
       bio: null,
       genre: [],
+      instagram: null,
+      soundcloud: null,
       spotify: null,
       bookingEmail: formData.email,
       defaultFee: formData.fee,
@@ -379,6 +392,8 @@ export async function createArtistAndAddToEvent(formData: {
       return { error: created.error ?? "Failed to create artist", artistId: null };
     }
 
+    // Book onto the event using the existing pathway (which handles auth,
+    // ownership, set-time resolution, chat sync, contact upsert, etc).
     const booked = await addArtistToEvent({
       eventId: formData.eventId,
       artistId: created.artist.id,
@@ -392,15 +407,87 @@ export async function createArtistAndAddToEvent(formData: {
       return { error: booked.error, artistId: created.artist.id };
     }
 
-    // Optional magic-link invite (best-effort)
+    // Optional invite. Best-effort — never block the booking on an email
+    // failure. We send a fully-branded Nocturn email (Resend) with event
+    // details + an accept link that takes the artist through a Supabase
+    // magic-link sign-in on the landing side. Previously this used
+    // `admin.auth.admin.inviteUserByEmail`, which fired Supabase's default
+    // template with no event context and off-brand styling.
     if (formData.sendInvite && formData.email) {
       try {
+        const sbServer = await createServerClient();
+        const { data: { user: currentUser } } = await sbServer.auth.getUser();
         const admin = createAdminClient();
         const appUrl = process.env.NEXT_PUBLIC_APP_URL ?? "https://app.trynocturn.com";
-        await admin.auth.admin.inviteUserByEmail(formData.email.toLowerCase().trim(), {
-          redirectTo: `${appUrl}/dashboard/artists/me`,
-          data: { full_name: formData.name, user_type: "artist", artist_profile_id: created.artist.id },
+        const email = formData.email.toLowerCase().trim();
+
+        // Generate a magic link the artist can click to land on /dashboard/artists/me
+        // without setting a password.
+        const { data: linkData } = await admin.auth.admin.generateLink({
+          type: "magiclink",
+          email,
+          options: {
+            redirectTo: `${appUrl}/dashboard/artists/me`,
+            data: { full_name: formData.name, user_type: "artist", artist_id: created.artist.id },
+          },
         });
+        const actionLink = linkData?.properties?.action_link
+          ?? `${appUrl}/login?email=${encodeURIComponent(email)}`;
+
+        // Pull event + collective context for a useful email body.
+        const [{ data: eventRow }, { data: collectiveRow }] = await Promise.all([
+          admin
+            .from("events")
+            .select("title, starts_at, venue_name, collective_id")
+            .eq("id", formData.eventId)
+            .maybeSingle(),
+          currentUser
+            ? admin
+                .from("collective_members")
+                .select("collective_id, collectives:collective_id(name)")
+                .eq("user_id", currentUser.id)
+                .is("deleted_at", null)
+                .limit(1)
+                .maybeSingle()
+            : Promise.resolve({ data: null }),
+        ]);
+
+        const eventTitle = eventRow?.title ?? "an upcoming event";
+        const eventDate = eventRow?.starts_at
+          ? new Date(eventRow.starts_at).toLocaleDateString("en", { weekday: "short", month: "short", day: "numeric", year: "numeric", hour: "numeric", minute: "2-digit" })
+          : "TBD";
+        const venueName = eventRow?.venue_name ?? null;
+        const collectiveName = ((collectiveRow?.collectives as unknown as { name?: string } | null)?.name) ?? "A collective";
+        const setTime = formData.setTime
+          ? `${new Date(formData.setTime).toLocaleTimeString("en", { hour: "numeric", minute: "2-digit" })}${formData.setDuration ? ` (${formData.setDuration} min)` : ""}`
+          : null;
+        const feeDisplay = typeof formData.fee === "number" && formData.fee > 0
+          ? `CA$${formData.fee.toFixed(2)}`
+          : null;
+
+        const firstName = (formData.name ?? "").trim().split(/\s+/)[0] ?? "there";
+
+        const { lineupInviteEmail } = await import("@/lib/email/templates");
+        const { sendEmail } = await import("@/lib/email/send");
+        const html = lineupInviteEmail({
+          artistFirstName: firstName,
+          collectiveName,
+          eventTitle,
+          eventDate,
+          venueName,
+          setTime,
+          feeDisplay,
+          acceptLink: actionLink,
+        });
+
+        const result = await sendEmail({
+          to: email,
+          subject: `You're booked — ${eventTitle}`,
+          html,
+        });
+        if (result.error) {
+          console.error("[createArtistAndAddToEvent] lineup invite email failed:", result.error);
+        }
       } catch (inviteErr) {
         console.error("[createArtistAndAddToEvent] invite failed (non-blocking):", inviteErr);
       }

--- a/src/lib/email/templates.ts
+++ b/src/lib/email/templates.ts
@@ -22,24 +22,29 @@ function sanitizeUrl(url: string): string {
 }
 
 function baseTemplate(content: string): string {
+  // Fonts: Outfit for headings, DM Sans for body. Loaded via Google Fonts
+  // link — most modern email clients honour webfonts; Apple Mail, Gmail, and
+  // iOS Mail render them, Outlook desktop falls back to the system stack.
   return `<!DOCTYPE html>
 <html>
 <head>
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <link href="https://fonts.googleapis.com/css2?family=Outfit:wght@500;700;800&family=DM+Sans:wght@400;500;600&display=swap" rel="stylesheet">
   <style>
-    body { margin: 0; padding: 0; background: #09090B; font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif; }
+    body { margin: 0; padding: 0; background: #09090B; font-family: 'DM Sans', -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif; }
     .container { max-width: 480px; margin: 0 auto; padding: 40px 24px; }
-    .logo { color: #7B2FF7; font-size: 24px; font-weight: 700; letter-spacing: -0.5px; text-decoration: none; }
+    .logo { color: #7B2FF7; font-family: 'Outfit', -apple-system, sans-serif; font-size: 26px; font-weight: 700; letter-spacing: -0.5px; text-decoration: none; }
     .content { margin-top: 32px; color: #FAFAFA; font-size: 15px; line-height: 1.6; }
-    .content h2 { color: #FAFAFA; font-size: 20px; font-weight: 600; margin: 0 0 16px 0; }
+    .content h2 { color: #FAFAFA; font-family: 'Outfit', -apple-system, sans-serif; font-size: 22px; font-weight: 700; letter-spacing: -0.3px; margin: 0 0 16px 0; }
     .content p { margin: 0 0 16px 0; color: #A1A1AA; }
-    .btn { display: inline-block; background: #7B2FF7; color: #FFFFFF !important; padding: 12px 32px; border-radius: 8px; text-decoration: none; font-weight: 600; font-size: 15px; margin: 8px 0 24px 0; }
-    .btn:hover { background: #A855F7; }
-    .footer { margin-top: 40px; padding-top: 24px; border-top: 1px solid rgba(255,255,255,0.1); color: #52525B; font-size: 12px; }
+    .btn { display: inline-block; background: #7B2FF7; color: #FFFFFF !important; padding: 14px 32px; border-radius: 10px; text-decoration: none; font-family: 'DM Sans', sans-serif; font-weight: 600; font-size: 15px; margin: 8px 0 24px 0; }
+    .btn:hover { background: #9D5CFF; }
+    .footer { margin-top: 40px; padding-top: 24px; border-top: 1px solid rgba(255,255,255,0.08); color: #52525B; font-size: 12px; line-height: 1.5; }
     .footer a { color: #7B2FF7; text-decoration: none; }
+    .tagline { color: #71717A; font-style: italic; font-size: 13px; margin: 0 0 8px 0; }
     .highlight { color: #7B2FF7; font-weight: 600; }
-    .card { background: #1C1C22; border: 1px solid rgba(255,255,255,0.1); border-radius: 12px; padding: 20px; margin: 16px 0; }
+    .card { background: #18181B; border: 1px solid rgba(255,255,255,0.07); border-radius: 14px; padding: 20px; margin: 16px 0; }
   </style>
 </head>
 <body>
@@ -49,7 +54,8 @@ function baseTemplate(content: string): string {
       ${content}
     </div>
     <div class="footer">
-      <p>Powered by <a href="https://app.trynocturn.com">nocturn.</a> — AI for music collectives and promoters</p>
+      <p class="tagline">You run the night. Nocturn runs the business.</p>
+      <p>Powered by <a href="https://app.trynocturn.com">nocturn.</a></p>
     </div>
   </div>
 </body>
@@ -68,6 +74,45 @@ export function welcomeEmail(name: string, collectiveName: string): string {
     </div>
     <a href="https://app.trynocturn.com/dashboard" class="btn">Open Dashboard →</a>
     <p>Need help? Just reply to this email.</p>
+  `);
+}
+
+/**
+ * Lineup invite — sent to a DJ / artist when a collective books them onto
+ * an event. Unlike a generic magic link, this puts the event + collective +
+ * set details up front so the artist immediately understands what the email
+ * is about and what to do.
+ */
+export function lineupInviteEmail(params: {
+  artistFirstName: string;
+  collectiveName: string;
+  eventTitle: string;
+  eventDate: string;
+  venueName: string | null;
+  setTime: string | null;
+  feeDisplay: string | null;
+  acceptLink: string;
+}): string {
+  const safeFirst = escapeHtml(params.artistFirstName || "there");
+  const safeCollective = escapeHtml(params.collectiveName);
+  const safeEvent = escapeHtml(params.eventTitle);
+  const safeDate = escapeHtml(params.eventDate);
+  const safeVenue = params.venueName ? escapeHtml(params.venueName) : null;
+  const safeSet = params.setTime ? escapeHtml(params.setTime) : null;
+  const safeFee = params.feeDisplay ? escapeHtml(params.feeDisplay) : null;
+  return baseTemplate(`
+    <h2>${safeFirst} — you're booked 🎧</h2>
+    <p><span class="highlight">${safeCollective}</span> added you to the lineup for <span class="highlight">${safeEvent}</span>. Here are the details:</p>
+    <div class="card">
+      <p style="color:#FAFAFA; margin:0 0 10px 0; font-family:'Outfit',sans-serif; font-size:18px; font-weight:700;">${safeEvent}</p>
+      <p style="margin:0 0 4px 0;">📅 ${safeDate}</p>
+      ${safeVenue ? `<p style="margin:0 0 4px 0;">📍 ${safeVenue}</p>` : ""}
+      ${safeSet ? `<p style="margin:0 0 4px 0;">🎛️ Set: ${safeSet}</p>` : ""}
+      ${safeFee ? `<p style="margin:8px 0 0 0; color:#7B2FF7; font-weight:600;">Fee: ${safeFee}</p>` : ""}
+    </div>
+    <p>Accept the booking on Nocturn to see your advance, confirm set time, and coordinate with the crew.</p>
+    <a href="${sanitizeUrl(params.acceptLink)}" class="btn">Review & confirm →</a>
+    <p style="color:#71717A; font-size:13px;">Not expecting this? You can ignore the email — nothing changes on your end.</p>
   `);
 }
 


### PR DESCRIPTION
Closes [NOC-23](https://linear.app/nocturn/issue/NOC-23/email-brand-dj-lineup-invite-basetemplate-overhaul-outfitdm-sans).

DJ lineup invite was firing Supabase's default magic-link template — no branding, no event context. Read like a password reset.

## New template — \`lineupInviteEmail\`

\`src/lib/email/templates.ts\` — takes \`{ artistFirstName, collectiveName, eventTitle, eventDate, venueName, setTime, feeDisplay, acceptLink }\` and renders a properly-branded email with event details up front. Recipient sees who booked them, for what, when, where, and what fee before clicking.

## \`baseTemplate\` overhaul

- Outfit (logo + h2) + DM Sans (body) via Google Fonts \`<link>\`. Falls back to system stack in clients that strip webfonts.
- Footer: tagline \`You run the night. Nocturn runs the business.\` above \`Powered by nocturn.\`
- Button: 14px padding, 10px radius, hover \`#9D5CFF\` matching in-app style.
- Card background \`#18181B\` matches Zinc-950.

## \`src/app/actions/artists.ts\` DJ invite rewrite

- Replaced \`inviteUserByEmail()\` with \`admin.auth.admin.generateLink({ type: \"magiclink\" })\` + Resend send of the new template.
- Pulls event title / date / venue / collective inline so email body has context.
- Still best-effort; send failure logged, booking still succeeds.
- Preserves magic-link sign-in behavior on \`/dashboard/artists/me\`.

## Not in scope

- The 5 other emails that bypass \`baseTemplate\` (event-reminders, ticket-waitlist, refunds, send-campaign, auth welcome). On-brand color-wise but duplicate CSS. Follow-up polish.
- \`settlement-email.ts\` — still plain text in a \`<pre>\`. Needs its own template.

## Test plan

- [ ] Add a DJ to event lineup with email + \"Send invite\" → DJ receives Nocturn-branded email from \`noreply@trynocturn.com\`.
- [ ] Subject = \`You're booked — {event title}\`.
- [ ] Body includes event name + date + venue + set time + fee.
- [ ] \"Review & confirm\" CTA lands DJ on \`/dashboard/artists/me\` signed in.
- [ ] Existing emails (ticket confirmation, welcome, member invite) still render with updated font + footer.

🤖 Generated with [Claude Code](https://claude.com/claude-code)