### PR TITLE
fix(forecast): wrap signed currency in non-breaking span (A5, NOC-21)

### DIFF
--- a/src/components/event-financials-dashboard.tsx
+++ b/src/components/event-financials-dashboard.tsx
@@ -16,6 +16,12 @@ function formatCurrency(n: number): string {
   }).format(n);
 }
 
+// Signed currency in a single non-breaking chunk so the minus sign never
+// wraps onto its own line inside tight table cells.
+function formatSignedCurrency(n: number): string {
+  return n < 0 ? `\u2212${formatCurrency(Math.abs(n))}` : formatCurrency(n);
+}
+
 interface Props {
   financials: EventFinancials;
   forecast: ForecastData | null;
@@ -278,12 +284,11 @@ export function EventFinancialsDashboard({ financials, forecast, trajectory }: P
                             </td>
                             <td className="px-3 py-2 text-right text-xs font-mono tabular-nums">
                               <span
-                                className={
+                                className={`whitespace-nowrap ${
                                   s.profit >= 0 ? "text-emerald-400" : "text-red-400"
-                                }
+                                }`}
                               >
-                                {s.profit >= 0 ? "" : "-"}
-                                {formatCurrency(Math.abs(s.profit))}
+                                {formatSignedCurrency(s.profit)}
                               </span>
                             </td>
                           </tr>

--- a/src/components/event-pnl-spreadsheet.tsx
+++ b/src/components/event-pnl-spreadsheet.tsx
@@ -819,7 +819,7 @@ export function EventPnlSpreadsheet({ financials }: Props) {
             <div className={`px-4 py-4 flex items-center justify-between ${isProfitable ? "bg-green-500/10" : "bg-red-500/10"}`}>
               <span className="text-sm font-bold uppercase tracking-wide">{isProfitable ? "Profit" : "Loss"}</span>
               <span className={`text-lg font-black font-mono tabular-nums ${isProfitable ? "text-green-400" : "text-red-400"}`}>
-                {isProfitable ? "" : "-"}{formatCurrency(Math.abs(financials.profitLoss))}
+                <span className="whitespace-nowrap">{isProfitable ? "" : "\u2212"}{formatCurrency(Math.abs(financials.profitLoss))}</span>
               </span>
             </div>
           </div>
@@ -1281,15 +1281,15 @@ export function EventPnlSpreadsheet({ financials }: Props) {
                   <span className={`text-lg font-black font-mono tabular-nums ${
                     isProfitable ? "text-green-400" : "text-red-400"
                   }`}>
-                    {isProfitable ? "" : "-"}{formatCurrency(Math.abs(financials.profitLoss))}
+                    <span className="whitespace-nowrap">{isProfitable ? "" : "\u2212"}{formatCurrency(Math.abs(financials.profitLoss))}</span>
                   </span>
                 </td>
                 {forecasts.map((f, fi) => (
                   <td key={fi} className="px-3 py-4 text-right">
-                    <span className={`text-sm font-bold font-mono tabular-nums ${
+                    <span className={`text-sm font-bold font-mono tabular-nums whitespace-nowrap ${
                       f.profit >= 0 ? "text-green-400" : "text-red-400"
                     }`}>
-                      {f.profit < 0 && "−"}{formatCurrency(Math.abs(f.profit))}
+                      {f.profit < 0 ? "\u2212" : ""}{formatCurrency(Math.abs(f.profit))}
                     </span>
                   </td>
                 ))}


### PR DESCRIPTION
Code-only split from #96. Part of [NOC-21](https://linear.app/nocturn/issue/NOC-21).

## What this fixes

Forecast LOSS row: \`−\` and \`CA\$5,118.00\` were two text nodes inside a span without whitespace-nowrap; narrow \`<td>\` line-broke between them.

## Files

- \`src/components/event-financials-dashboard.tsx\` — \`formatSignedCurrency()\` helper using Unicode U+2212 minus + whitespace-nowrap
- \`src/components/event-pnl-spreadsheet.tsx\` — same pattern for Profit/Loss total + forecast cells

## Math note

The 75% / 100% columns appearing identical is by design — those are Sell-out / Waitlist; cascadeScenario() caps demand at capacity. No math change shipped.

## Test plan

- [ ] /dashboard/events/{id}/financials → LOSS renders on one line across all columns
- [ ] tsc clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)