### PR TITLE
feat(auth): seed general channel on createCollective (A6, NOC-21)

### DIFF
--- a/src/app/actions/auth.ts
+++ b/src/app/actions/auth.ts
@@ -399,6 +399,17 @@ export async function createCollective(formData: {
     return { error: "Failed to add you as admin" };
   }
 
+  // Seed a #general channel so the team chat isn't empty on first load.
+  // Best-effort — the Messages page also has a lazy-create fallback, but
+  // landing on a populated chat is a better first impression than an empty
+  // state asking the operator to create a conversation themselves.
+  const { error: channelError } = await admin
+    .from("channels")
+    .insert({ collective_id: collective.id, name: "General", type: "general", created_by: user.id });
+  if (channelError) {
+    console.error("[createCollective] general channel seed error (non-blocking):", channelError.message);
+  }
+
   return { error: null };
   } catch (err) {
     console.error("[createCollective] Unexpected error:", err);


### PR DESCRIPTION
Code-only split from #96. Part of [NOC-21](https://linear.app/nocturn/issue/NOC-21).

## What this fixes

New collectives landed on an empty Messages page on first load. Seeding a \`general\` channel during \`createCollective\` gives operators a populated chat immediately.

## Files

- \`src/app/actions/auth.ts\` — INSERT into existing \`channels\` table with existing columns. Best-effort; failure logged but doesn't block onboarding.

## Out of scope

- Backfilling existing collectives → separate Linear ticket (Andrew applies the one-off SQL).

## Test plan

- [ ] Sign up a new collective via /onboarding
- [ ] Navigate to /dashboard/chat → General channel appears immediately
- [ ] tsc clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)