### PR TITLE
fix(next-image): widen Supabase hostname to **.supabase.co (B1, NOC-22)

### DIFF
--- a/next.config.ts
+++ b/next.config.ts
@@ -50,7 +50,7 @@ const nextConfig: NextConfig = {
     remotePatterns: [
       {
         protocol: "https",
-        hostname: "zvmslijvdkcnkrjjgaie.supabase.co",
+        hostname: "**.supabase.co",
         pathname: "/storage/**",
       },
       {


### PR DESCRIPTION
Code-only split from #97. Part of [NOC-22](https://linear.app/nocturn/issue/NOC-22).

## What this fixes

\`next.config.ts\` only whitelisted the prod Supabase hostname; QA's host (and any preview branch's host) would 400 in \`next/image\`. Widening to \`**.supabase.co\` makes flyer rendering work in all environments.

## Files

- \`next.config.ts\` — \`images.remotePatterns\` hostname change

## Out of scope

The \`event-assets\` bucket provisioning — separate Linear ticket for Andrew (deploy mechanism choice).

## Test plan

- [ ] Once a flyer exists in QA's bucket, the public event page renders it via next/image without warning
- [ ] tsc + build clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)