### PR TITLE
fix(p0): schema-drift \u2014 crm-enrichment + artist detail page

### DIFF
--- a/src/app/(dashboard)/dashboard/artists/[artistId]/page.tsx
+++ b/src/app/(dashboard)/dashboard/artists/[artistId]/page.tsx
@@ -35,8 +35,11 @@ interface Booking {
   id: string;
   fee: number | null;
   set_time: string | null;
-  set_duration: number | null;
-  status: string;
+  // Post-#93 rename: set_duration -> set_length. Booking state column was
+  // also dropped; presence in event_artists implies confirmed. `role`
+  // stores lineup position (headliner / support / opener).
+  set_length: number | null;
+  role: string | null;
   notes: string | null;
   events: {
     id: string;
@@ -83,11 +86,13 @@ export default function ArtistDetailPage() {
       });
     }
 
-    // Get all bookings for this artist with event details
+    // Get all bookings for this artist with event details.
+    // Post-#93: set_duration -> set_length; status column dropped (bookings
+    // in the table are implicitly confirmed); role stores lineup position.
     const { data: bookingData } = await supabase
       .from("event_artists")
       .select(
-        "id, fee, set_time, set_duration, status, notes, events(id, title, starts_at, status)"
+        "id, fee, set_time, set_length, role, notes, events(id, title, starts_at, status)"
       )
       .eq("party_id", artistId)
       .order("created_at", { ascending: false });
@@ -147,34 +152,31 @@ export default function ArtistDetailPage() {
     );
   }
 
+  // Post-#93: booking.status column dropped — no "cancelled" state to
+  // filter by. Everything in the table is considered active.
   const upcoming = bookings.filter(
-    (b) =>
-      b.events &&
-      new Date(b.events.starts_at) >= new Date() &&
-      b.status !== "cancelled"
+    (b) => b.events && new Date(b.events.starts_at) >= new Date()
   );
   const past = bookings.filter(
-    (b) =>
-      b.events &&
-      (new Date(b.events.starts_at) < new Date() || b.status === "cancelled")
+    (b) => b.events && new Date(b.events.starts_at) < new Date()
   );
 
+  // Post-#93: booking state column dropped. Presence in event_artists
+  // implies confirmed; role stores lineup position.
   const totalEarnings = bookings
-    .filter((b) => b.status === "confirmed" && b.fee)
+    .filter((b) => b.fee)
     .reduce((sum, b) => sum + (b.fee ?? 0), 0);
 
-  const statusColors: Record<string, string> = {
-    pending: "bg-yellow-500/10 text-yellow-500",
-    confirmed: "bg-emerald-500/10 text-emerald-500",
-    declined: "bg-red-500/10 text-red-500",
-    cancelled: "bg-muted text-muted-foreground",
+  const roleColors: Record<string, string> = {
+    headliner: "bg-nocturn/10 text-nocturn",
+    support: "bg-emerald-500/10 text-emerald-500",
+    opener: "bg-yellow-500/10 text-yellow-500",
   };
 
-  const statusIcons: Record<string, typeof Check> = {
-    pending: Clock,
-    confirmed: Check,
-    declined: X,
-    cancelled: X,
+  const roleIcons: Record<string, typeof Check> = {
+    headliner: Check,
+    support: Check,
+    opener: Clock,
   };
 
   return (
@@ -294,7 +296,7 @@ export default function ArtistDetailPage() {
             Upcoming Events
           </h2>
           {upcoming.map((booking) => (
-            <BookingCard key={booking.id} booking={booking} statusColors={statusColors} statusIcons={statusIcons} />
+            <BookingCard key={booking.id} booking={booking} roleColors={roleColors} roleIcons={roleIcons} />
           ))}
         </div>
       )}
@@ -306,7 +308,7 @@ export default function ArtistDetailPage() {
             Past Events
           </h2>
           {past.map((booking) => (
-            <BookingCard key={booking.id} booking={booking} statusColors={statusColors} statusIcons={statusIcons} />
+            <BookingCard key={booking.id} booking={booking} roleColors={roleColors} roleIcons={roleIcons} />
           ))}
         </div>
       )}
@@ -336,15 +338,16 @@ export default function ArtistDetailPage() {
 
 function BookingCard({
   booking,
-  statusColors,
-  statusIcons,
+  roleColors,
+  roleIcons,
 }: {
   booking: Booking;
-  statusColors: Record<string, string>;
-  statusIcons: Record<string, typeof Check>;
+  roleColors: Record<string, string>;
+  roleIcons: Record<string, typeof Check>;
 }) {
   const date = new Date(booking.events.starts_at);
-  const StatusIcon = statusIcons[booking.status] ?? Clock;
+  const roleKey = booking.role ?? "";
+  const RoleIcon = roleIcons[roleKey] ?? Clock;
 
   return (
     <Link href={`/dashboard/events/${booking.events.id}/lineup`}>
@@ -362,16 +365,16 @@ function BookingCard({
             <p className="font-medium truncate">{booking.events.title}</p>
             <div className="flex items-center gap-3 text-xs text-muted-foreground">
               {booking.fee && <span>${booking.fee}</span>}
-              {booking.set_duration && <span>{booking.set_duration}min</span>}
+              {booking.set_length && <span>{booking.set_length}min</span>}
             </div>
           </div>
           <span
             className={`flex items-center gap-1 rounded-full px-2 py-0.5 text-xs font-medium capitalize ${
-              statusColors[booking.status] ?? ""
+              roleColors[roleKey] ?? "bg-muted text-muted-foreground"
             }`}
           >
-            <StatusIcon className="h-3 w-3" />
-            {booking.status}
+            <RoleIcon className="h-3 w-3" />
+            {booking.role ?? "artist"}
           </span>
         </CardContent>
       </Card>

--- a/src/app/actions/crm-enrichment.ts
+++ b/src/app/actions/crm-enrichment.ts
@@ -17,11 +17,11 @@ export async function enrichAttendeeCRM(eventId: string) {
   const admin = createAdminClient();
 
   // Verify ownership
+  // Post-#93: events dropped deleted_at (status lifecycle replaces soft delete).
   const { data: ev, error: evError } = await admin
     .from("events")
     .select("collective_id")
     .eq("id", eventId)
-    .is("deleted_at", null)
     .maybeSingle();
   if (evError) {
     console.error("[enrichAttendeeCRM] event query error:", evError.message);


### PR DESCRIPTION
## Summary

Two P0 schema-drift bugs surfaced by parallel agent audit. Fix both.

### Bug 1 — `src/app/actions/crm-enrichment.ts:24`
`events` query still filtered `.is("deleted_at", null)`. That column was dropped in PR #93 (status lifecycle replaced soft delete). Every call 400s with \"Failed to load event.\"

**Fix:** remove the filter.

### Bug 2 — `src/app/(dashboard)/dashboard/artists/[artistId]/page.tsx`
SELECT read `event_artists.status` and `event_artists.set_duration`. Both renamed/dropped in PR #93:
- `set_duration` → `set_length`
- `status` column removed entirely; presence in `event_artists` implies active booking

The errored query returned no bookings — artist detail page rendered as a blank card with no upcoming/past events and no total-fees figure.

**Fix:**
- `Booking` interface + SELECT string updated
- `upcoming`/`past`/`totalEarnings` filters drop the `.status` check
- Replaced `statusColors`/`statusIcons` (pending/confirmed/declined/cancelled) with `roleColors`/`roleIcons` keyed on the actual values in the column today (headliner/support/opener per the seed data + `artists.ts` booking flow)

## Follow-up tickets to file (not in this PR)

These are P1 (dead UX, not blocking):

- **NOC-33** — public event page `event.event_mode` always undefined; every event forced into \"ticketed\" mode. Effectively-free fallback rescues $0 events but explicit RSVP/hybrid events with paid tiers are silently broken.
- **NOC-34** — `event_tasks.priority` + `.metadata.task_type` + `.category` reads across tasks page, dashboard-home My Tasks, and `tasks.ts` input types. Priority dots, category pills, content-type filters all dead. Includes type-lie in `createEventTask` (accepts params that get silently dropped).

Stripe Connect flow (`stripe-connect.ts` reads dropped `collectives.stripe_account_id`) is already tracked as NOC-27 — blocked on Andrew's schema pick.

## Governance

- **Schema changes**: none
- **Migrations**: none
- **RLS policies**: unchanged

## Test plan

- [x] `npx tsc --noEmit` clean
- [ ] Artist detail page renders with seed data lineup (LockEight has 2 bookings from the demo seed)
- [ ] CRM enrich on any event no longer 400s

\ud83e\udd16 Generated with [Claude Code](https://claude.com/claude-code)