### PR TITLE
fix(tasks): remove dropped-column reads + hide empty Content tab (NOC-32)

### DIFF
--- a/src/app/(dashboard)/dashboard/events/[eventId]/tasks/page.tsx
+++ b/src/app/(dashboard)/dashboard/events/[eventId]/tasks/page.tsx
@@ -157,9 +157,13 @@ function EventTasksPageInner() {
   const [suggestions, setSuggestions] = useState<Suggestion[]>([]);
   const [eventDate, setEventDate] = useState<string | null>(null);
   const [loading, setLoading] = useState(true);
-  const [activeTab, setActiveTab] = useState<"tasks" | "content" | "feed">(() => {
+  // NOC-32: "content" tab removed — it was populated by filtering
+  // event_tasks.metadata.task_type === "content", and the metadata column
+  // was dropped in PR #93 so the tab is permanently empty. If URL has
+  // ?tab=content legacy link, land on Tasks instead.
+  const [activeTab, setActiveTab] = useState<"tasks" | "feed">(() => {
     const tab = searchParams.get("tab");
-    return tab === "content" ? "content" : "tasks";
+    return tab === "feed" ? "feed" : "tasks";
   });
 
   // Filters
@@ -217,10 +221,12 @@ function EventTasksPageInner() {
     }
     setAdding(true);
     setFormError(null);
+    // NOC-32: category param dropped — event_tasks.category column removed
+    // in PR #93. newCategory state is still captured for future re-add.
+    void newCategory;
     const result = await createEventTask({
       eventId,
       title: newTitle,
-      category: newCategory,
       dueDate: newDueDate || undefined,
     });
     if (result?.error) {
@@ -300,12 +306,13 @@ function EventTasksPageInner() {
 
   async function handleAddSuggestion(suggestion: Suggestion, idx: number) {
     setAddingSuggestionIdx(idx);
+    // NOC-32: category + priority columns dropped in PR #93. Suggestion
+    // shape still carries them for future UI use (scoring, sorting) but
+    // they're not persisted.
     await createEventTask({
       eventId,
       title: suggestion.title,
       description: suggestion.description,
-      category: suggestion.category,
-      priority: suggestion.priority,
     });
     await loadAll(false);
     setAddingSuggestionIdx(null);
@@ -538,19 +545,14 @@ function EventTasksPageInner() {
         </div>
       )}
 
-      {/* Tabs */}
+      {/* Tabs — NOC-32 removed the Content tab (permanently empty after
+          event_tasks.metadata was dropped in PR #93). */}
       <div className="flex gap-1 rounded-lg bg-muted p-1">
         <button
           onClick={() => setActiveTab("tasks")}
           className={`flex-1 rounded-md px-3 py-1.5 text-sm font-medium transition-colors min-h-[44px] ${activeTab === "tasks" ? "bg-background shadow-sm" : "text-muted-foreground"}`}
         >
           <ListChecks className="inline h-4 w-4 mr-1" /> Tasks
-        </button>
-        <button
-          onClick={() => setActiveTab("content")}
-          className={`flex-1 rounded-md px-3 py-1.5 text-sm font-medium transition-colors min-h-[44px] ${activeTab === "content" ? "bg-background shadow-sm" : "text-muted-foreground"}`}
-        >
-          <Image className="inline h-4 w-4 mr-1" /> Content
         </button>
         <button
           onClick={() => setActiveTab("feed")}
@@ -759,8 +761,8 @@ function EventTasksPageInner() {
         </div>
       )}
 
-      {/* ═══ CONTENT TAB ═══ */}
-      {activeTab === "content" && (
+      {/* ═══ CONTENT TAB (NOC-32: removed — metadata column dropped) ═══ */}
+      {false && (
         <div className="space-y-4">
           {/* Search + filters for content */}
           <div className="relative">

--- a/src/app/(dashboard)/dashboard/page.tsx
+++ b/src/app/(dashboard)/dashboard/page.tsx
@@ -207,14 +207,14 @@ export default async function DashboardPage() {
       totalTicketsSold={totalTicketsSold}
       actionItems={actionItems}
       myTasks={myTasksData.map((t: Record<string, unknown>) => ({
+        // NOC-32: priority + metadata.task_type dropped in PR #93.
+        // Dashboard Home no longer surfaces priority dots or the Content pill.
         id: t.id as string,
         title: t.title as string,
         eventTitle: ((t.events as Record<string, unknown>)?.title as string) ?? "Event",
         eventId: t.event_id as string,
         dueAt: (t.due_at as string) ?? null,
-        priority: (t.priority as string) ?? null,
         status: (t.status as string) ?? "todo",
-        isContent: ((t.metadata as Record<string, unknown>)?.task_type as string) === "content",
       }))}
     />
   );

--- a/src/app/actions/tasks.ts
+++ b/src/app/actions/tasks.ts
@@ -157,13 +157,13 @@ export async function getEventTasks(eventId: string) {
 }
 
 // Create a single task
-// TODO(audit): validate priority/category enums, UUID-validate assignedTo
+// NOC-32: category + priority params removed — underlying columns were
+// dropped in PR #93. Previous versions silently discarded these at INSERT
+// (type lie). If product wants them back, file a schema ticket first.
 export async function createEventTask(input: {
   eventId: string;
   title: string;
   description?: string;
-  category?: string;
-  priority?: string;
   assignedTo?: string;
   dueDate?: string;
 }) {

--- a/src/components/dashboard-home.tsx
+++ b/src/components/dashboard-home.tsx
@@ -69,15 +69,16 @@ interface DashboardHomeProps {
   hasPublishedEvent?: boolean;
   totalTicketsSold?: number;
   actionItems?: ActionItemData[];
+  // NOC-32: priority + isContent removed — event_tasks.priority and
+  // .metadata were dropped in PR #93. See NOC-32 for re-introduction
+  // options if product needs task priority back.
   myTasks?: Array<{
     id: string;
     title: string;
     eventTitle: string;
     eventId: string;
     dueAt: string | null;
-    priority: string | null;
     status: string;
-    isContent: boolean;
   }>;
 }
 
@@ -510,16 +511,13 @@ export function DashboardHome(props: DashboardHomeProps) {
               <Link key={task.id} href={`/dashboard/events/${task.eventId}/tasks`}>
                 <Card className="rounded-2xl hover:border-nocturn/20 hover:shadow-md hover:shadow-nocturn/5 transition-all duration-200 active:scale-[0.98]">
                   <CardContent className="p-3 flex items-center gap-3">
-                    <div className={`h-2 w-2 rounded-full shrink-0 ${
-                      task.priority === "urgent" ? "bg-red-500" :
-                      task.priority === "high" ? "bg-amber-500" :
-                      "bg-nocturn"
-                    }`} />
+                    {/* NOC-32: priority dot color logic removed — priority column
+                        dropped in PR #93. Flat nocturn dot for all tasks. */}
+                    <div className="h-2 w-2 rounded-full shrink-0 bg-nocturn" />
                     <div className="flex-1 min-w-0">
                       <p className="text-sm font-medium truncate">{task.title}</p>
                       <p className="text-xs text-muted-foreground truncate">{task.eventTitle}{task.dueAt ? ` · Due ${formatRelativeDate(task.dueAt)}` : ""}</p>
                     </div>
-                    {task.isContent && <span className="text-xs bg-nocturn/10 text-nocturn px-2 py-0.5 rounded-full shrink-0">Content</span>}
                   </CardContent>
                 </Card>
               </Link>


### PR DESCRIPTION
Closes [NOC-32](https://linear.app/nocturn/issue/NOC-32/event-tasks-ui-reads-dropped-prioritymetadatacategory-columns)

## The bug

PR #93 dropped four columns from \`event_tasks\`: \`priority\`, \`metadata\`, \`category\`, \`task_type\`. Multiple UI surfaces read them and silently got \`undefined\` → degraded UX (flat priority dots, empty Content tab, empty category filters, type lies in createEventTask).

## Changes — 4 files, ~27 lines

### 1. Dashboard Home "Your Tasks" widget
- \`src/app/(dashboard)/dashboard/page.tsx\` — stop mapping \`priority\` + \`isContent\` (both read dropped columns)
- \`src/components/dashboard-home.tsx\` — drop those fields from the prop type; flat \`bg-nocturn\` dot; remove "Content" pill

### 2. Event Playbook tasks page
- Remove Content tab button (it was split by \`metadata.task_type === "content"\` which is always undefined → tab was always empty → confusing in demos)
- Narrow \`activeTab\` type from \`"tasks" | "content" | "feed"\` → \`"tasks" | "feed"\`
- Legacy \`?tab=content\` URL param lands on Tasks
- Remove \`category\` + \`priority\` args from both \`createEventTask\` call sites

### 3. createEventTask server action
- Remove \`category\` + \`priority\` from input type. Previous versions accepted them and silently discarded at INSERT — a type lie. Callers that still pass them now fail TS (correct signal).

## What I didn't change (deliberate)

- **\`categoryConfig\` + \`filterCategory\` + \`getCategory\`** stay. \`getCategory\` always returns \`"general"\` now, collapsing the list into one group. The existing \`if (count === 0) return null\` already hides empty category pills, so only "General" shows.
- **Launch playbook templates** (\`src/app/actions/launch-playbook.ts\`) still carry category + priority as editorial metadata. When (if) the columns come back, those templates can populate them. For now, advisory only.
- **\`ContentTaskCard\` + \`contentTasks\` / \`filteredContent\` / \`contentSorted\`** left as dead code — easy restore path if schema re-adds metadata. TS is fine with them. They don't render (wrapped in \`{false && ...}\`).

## Why not re-add the columns

That's a product decision:
- Should priority be an enum (urgent/high/medium/low) or derived from due_at?
- Should category be fixed enum or free text?
- Is the Ops vs Content task split still desired post-chat-pause?

File a follow-up schema ticket if product wants these back. For now this PR matches the UI to the data that exists.

## Test plan

- [x] \`npx tsc --noEmit\` clean
- [ ] Dashboard home "Your Tasks" renders seeded tasks without priority dots
- [ ] Event playbook shows Tasks + Activity tabs only
- [ ] Can create a task manually (no category/priority fields sent)
- [ ] No Sleep Club seed's 25 tasks display cleanly under the single "General" group

## Governance

Schema changes: **none.** RLS policies: **unchanged.** Code-only.

\ud83e\udd16 Generated with [Claude Code](https://claude.com/claude-code)