### PR TITLE
fix(events/new): live break-even + $5 price snap + profit label

### DIFF
--- a/src/__tests__/ticket-forecast.test.ts
+++ b/src/__tests__/ticket-forecast.test.ts
@@ -1,0 +1,121 @@
+/**
+ * Ticket Forecast Tests
+ *
+ * Locks in the budget-math functions the event-creation wizard relies on:
+ * - multiplyBudgetTiers: Price sensitivity slider, must snap to $5
+ * - cascadeBreakEven: Break-even row on the Recommended Tiers card
+ */
+import { describe, it, expect } from "vitest";
+import {
+  multiplyBudgetTiers,
+  cascadeBreakEven,
+  type TicketTierInput,
+} from "@/lib/ticket-forecast";
+
+describe("multiplyBudgetTiers", () => {
+  const base = [
+    { name: "Early Bird", price: 25, capacity: 41 },
+    { name: "Tier 1", price: 35, capacity: 96 },
+    { name: "Tier 2", price: 45, capacity: 83 },
+    { name: "Tier 3", price: 55, capacity: 55 },
+  ];
+
+  it("returns unchanged prices at 1.0x when base prices are $5 multiples", () => {
+    const result = multiplyBudgetTiers(base, 1.0);
+    expect(result.map((t) => t.price)).toEqual([25, 35, 45, 55]);
+  });
+
+  it("snaps every tier to the nearest $5 at 0.85x (regression for CAD 21/30/38/47 bug)", () => {
+    const result = multiplyBudgetTiers(base, 0.85);
+    // Raw: 21.25, 29.75, 38.25, 46.75 → nearest $5: 20, 30, 40, 45
+    expect(result.map((t) => t.price)).toEqual([20, 30, 40, 45]);
+  });
+
+  it("snaps to $5 at 1.25x too", () => {
+    const result = multiplyBudgetTiers(base, 1.25);
+    // Raw: 31.25, 43.75, 56.25, 68.75 → nearest $5: 30, 45, 55, 70
+    expect(result.map((t) => t.price)).toEqual([30, 45, 55, 70]);
+  });
+
+  it("never produces a negative price", () => {
+    const result = multiplyBudgetTiers([{ name: "Weird", price: 10, capacity: 5 }], -2);
+    expect(result[0].price).toBeGreaterThanOrEqual(0);
+  });
+
+  it("preserves tier name and capacity", () => {
+    const result = multiplyBudgetTiers(base, 0.9);
+    expect(result.map((t) => ({ name: t.name, capacity: t.capacity }))).toEqual(
+      base.map((t) => ({ name: t.name, capacity: t.capacity })),
+    );
+  });
+
+  it("returns empty array for empty input", () => {
+    expect(multiplyBudgetTiers([], 1.0)).toEqual([]);
+  });
+
+  it("ignores extra fields on the input shape", () => {
+    const input = [{ name: "X", price: 20, capacity: 10, reasoning: "note" }];
+    const result = multiplyBudgetTiers(input, 1.0);
+    expect(result).toEqual([{ name: "X", price: 20, capacity: 10 }]);
+  });
+});
+
+describe("cascadeBreakEven (live recompute for Price Sensitivity slider)", () => {
+  const tiers: TicketTierInput[] = [
+    { name: "Early Bird", price: 20, capacity: 15, sort_order: 0 },
+    { name: "Tier 1", price: 24, capacity: 35, sort_order: 1 },
+    { name: "Tier 2", price: 32, capacity: 30, sort_order: 2 },
+    { name: "Tier 3", price: 36, capacity: 20, sort_order: 3 },
+  ];
+
+  it("returns zero tickets when expenses are zero", () => {
+    const be = cascadeBreakEven(tiers, 0);
+    expect(be.ticketsNeeded).toBe(0);
+    expect(be.achievable).toBe(true);
+  });
+
+  it("lands in the first tier when expenses are small", () => {
+    // EB: 15 * $20 = $300. Expenses $200 → need 10 EB tickets.
+    const be = cascadeBreakEven(tiers, 200);
+    expect(be.breakEvenTier).toBe("Early Bird");
+    expect(be.ticketsNeeded).toBe(10);
+    expect(be.atPrice).toBe(20);
+    expect(be.achievable).toBe(true);
+  });
+
+  it("cascades into Tier 2 when EB + T1 alone can't cover expenses", () => {
+    // EB maxes at $300, T1 maxes at $840 → cumulative $1140.
+    // Expenses $1500 → need $360 more at $32 → ceil(360/32) = 12 T2 tickets.
+    // Total: 15 EB + 35 T1 + 12 T2 = 62 tickets inside T2 at $32.
+    const be = cascadeBreakEven(tiers, 1500);
+    expect(be.breakEvenTier).toBe("Tier 2");
+    expect(be.atPrice).toBe(32);
+    expect(be.ticketsNeeded).toBe(62);
+  });
+
+  it("reports unachievable when even sell-out can't cover expenses", () => {
+    // Max revenue: 15*20 + 35*24 + 30*32 + 20*36 = 300+840+960+720 = 2820
+    const be = cascadeBreakEven(tiers, 5000);
+    expect(be.achievable).toBe(false);
+    expect(be.breakEvenTier).toBeNull();
+    expect(be.percentOfCapacity).toBe(1);
+  });
+
+  it("tracks when the slider raises prices (fewer tickets needed)", () => {
+    // Simulate what PricingSection does: multiply the tiers by 1.2x via $5-snap,
+    // then recompute break-even. Higher prices → fewer tickets to break-even.
+    const louder = multiplyBudgetTiers(tiers, 1.2);
+    const louderWithOrder = louder.map((t, i) => ({ ...t, sort_order: i }));
+    const baseBE = cascadeBreakEven(tiers, 1500);
+    const louderBE = cascadeBreakEven(louderWithOrder, 1500);
+    expect(louderBE.ticketsNeeded).toBeLessThan(baseBE.ticketsNeeded);
+  });
+
+  it("tracks when the slider lowers prices (more tickets needed)", () => {
+    const softer = multiplyBudgetTiers(tiers, 0.8);
+    const softerWithOrder = softer.map((t, i) => ({ ...t, sort_order: i }));
+    const baseBE = cascadeBreakEven(tiers, 1500);
+    const softerBE = cascadeBreakEven(softerWithOrder, 1500);
+    expect(softerBE.ticketsNeeded).toBeGreaterThan(baseBE.ticketsNeeded);
+  });
+});

--- a/src/app/(dashboard)/dashboard/events/new/page.tsx
+++ b/src/app/(dashboard)/dashboard/events/new/page.tsx
@@ -1080,7 +1080,7 @@ function LiveForecast({
           <div className="flex items-center gap-1.5">
             <TrendingUp className="h-3.5 w-3.5 text-nocturn" />
             <span className="text-xs font-semibold text-zinc-400 uppercase tracking-wider">
-              Revenue Forecast
+              {totalExpenses > 0 ? "Profit Forecast" : "Revenue Forecast"}
             </span>
           </div>
           <p className={`mt-1.5 text-3xl font-bold leading-none ${totalExpenses > 0 ? (projections[2].profit >= 0 ? "text-green-400" : "text-red-400") : "text-white"}`}>
@@ -1352,7 +1352,7 @@ function multiplyBudgetTiers(
   if (suggestedTiers.length === 0) return [];
   return suggestedTiers.map((tier) => ({
     name: tier.name,
-    price: Math.max(0, Math.round(tier.price * multiplier)),
+    price: Math.max(0, Math.round((tier.price * multiplier) / 5) * 5),
     capacity: tier.capacity,
   }));
 }
@@ -1621,6 +1621,21 @@ function BudgetStep({
         };
       })
     : [];
+
+  // Recompute break-even live off the slider-adjusted tiers so it tracks the
+  // "Price sensitivity" control. result.breakEven is frozen at Calculate Budget
+  // time and would otherwise show stale numbers while the operator simulates.
+  const liveBreakEven = result && suggestedPreview.length > 0
+    ? cascadeBreakEven(
+        suggestedPreview.map((t, i) => ({
+          name: t.name,
+          price: t.price,
+          capacity: t.capacity,
+          sort_order: i,
+        })),
+        result.totalExpenses,
+      )
+    : result?.breakEven;
 
   return (
     <div className="space-y-5 animate-fade-in">
@@ -1936,7 +1951,7 @@ function BudgetStep({
             )}
 
             <p className="text-xs text-zinc-400 pt-1">
-              Break-even: <span className="text-white font-medium">{result.breakEven.ticketsNeeded} tickets</span> at {result.breakEven.atPrice} {result.eventCurrency.toUpperCase()}
+              Break-even: <span className="text-white font-medium">{(liveBreakEven ?? result.breakEven).ticketsNeeded} tickets</span> at {(liveBreakEven ?? result.breakEven).atPrice} {result.eventCurrency.toUpperCase()}
             </p>
 
             <div className="space-y-1">

--- a/src/app/(dashboard)/dashboard/events/new/page.tsx
+++ b/src/app/(dashboard)/dashboard/events/new/page.tsx
@@ -14,7 +14,7 @@ import {
 } from "@/app/actions/budget-planner";
 import type { ExpenseCategory } from "@/lib/expense-categories";
 import { SUPPORTED_CURRENCIES } from "@/lib/currency";
-import { cascadeScenario, cascadeBreakEven, type TicketTierInput } from "@/lib/ticket-forecast";
+import { cascadeScenario, cascadeBreakEven, multiplyBudgetTiers, type TicketTierInput } from "@/lib/ticket-forecast";
 import { getMyCollectiveDefaults } from "@/app/actions/collective-settings";
 import { applyLaunchPlaybook } from "@/app/actions/launch-playbook";
 import { createClient } from "@/lib/supabase/client";
@@ -1342,18 +1342,6 @@ function scaleBudgetTiers(
     name: t.name,
     price: Math.round(t.price * ratio),
     capacity: t.capacity,
-  }));
-}
-
-function multiplyBudgetTiers(
-  suggestedTiers: Array<{ name: string; price: number; capacity: number; reasoning?: string }>,
-  multiplier: number
-): TicketTier[] {
-  if (suggestedTiers.length === 0) return [];
-  return suggestedTiers.map((tier) => ({
-    name: tier.name,
-    price: Math.max(0, Math.round((tier.price * multiplier) / 5) * 5),
-    capacity: tier.capacity,
   }));
 }
 

--- a/src/lib/ticket-forecast.ts
+++ b/src/lib/ticket-forecast.ts
@@ -190,6 +190,27 @@ export function cascadeBreakEven(
 }
 
 /**
+ * Scale each tier's price by `multiplier` and snap to the nearest $5.
+ *
+ * Used by the Budget step's "Price sensitivity" slider. Promoters price
+ * doors in $5 increments, so a 0.85x pass on a $25 tier should land at
+ * $20, not $21. Rounding to the nearest dollar (the old behavior)
+ * produced awkward prices like CAD 21/30/38/47 that no operator would
+ * actually charge.
+ */
+export function multiplyBudgetTiers<T extends { name: string; price: number; capacity: number }>(
+  suggestedTiers: T[],
+  multiplier: number,
+): Array<{ name: string; price: number; capacity: number }> {
+  if (suggestedTiers.length === 0) return [];
+  return suggestedTiers.map((tier) => ({
+    name: tier.name,
+    price: Math.max(0, Math.round((tier.price * multiplier) / 5) * 5),
+    capacity: tier.capacity,
+  }));
+}
+
+/**
  * Format a ScenarioResult's sold-pct label for display. Caps at 100% for
  * cascade-capped values and adds a "+N waitlist" suffix when there was
  * excess demand.


### PR DESCRIPTION
## Summary
Three small bugs in the Budget step's **Recommended Tiers** simulator on `/dashboard/events/new`:

1. **Break-even doesn't track the slider.** `result.breakEven` is frozen at Calculate Budget time. Now derived live via `cascadeBreakEven` off the slider-adjusted tiers.
2. **Tier prices land on odd numbers.** `multiplyBudgetTiers` rounded to the nearest \$1 (e.g. CAD 21/30/38/47 at 0.85x). Now rounds to the nearest \$5 so promoters always see clean door prices.
3. **"Revenue Forecast" headline is mislabeled.** The big number is already profit (`gross − expenses`) whenever expenses > 0. Now reads "Profit Forecast" / "Revenue Forecast" conditionally.

Pure-frontend, no schema, no server action touched.

## Test plan
- [ ] On `/dashboard/events/new`, reach the Budget step, click Calculate Budget, then slide "Price sensitivity"
  - [ ] All tier prices snap to multiples of \$5
  - [ ] "Break-even: N tickets at P CAD" updates as you slide
  - [ ] "Use these tiers in event draft" still pushes the displayed prices into the form
- [ ] On the "What if you charge..." card (the LiveForecast that appears once tiers exist), confirm:
  - [ ] Header reads "Profit Forecast" when expenses > 0, "Revenue Forecast" when expenses = 0
- [ ] Build + typecheck pass (verified locally)

🤖 Generated with [Claude Code](https://claude.com/claude-code)