### PR TITLE
schema(NOC-39): add collectives.stripe_account_id — MSB regulatory mitigation

### DIFF
--- a/supabase/migrations/20260422000002_add_collectives_stripe_account_id.sql
+++ b/supabase/migrations/20260422000002_add_collectives_stripe_account_id.sql
@@ -1,0 +1,42 @@
+-- Add collectives.stripe_account_id — single reference key for Stripe Connect.
+--
+-- Per Andrew's NOC-27 review + Shawn's MSB regulatory argument:
+--
+--   Andrew's NOC-27 framing: "the right model is storing one reference
+--   key only (account ID) and fetching everything else live from Stripe's
+--   API. No caching, no denormalized status columns."
+--
+--   Shawn's MSB argument: manual payouts = Nocturn holds customer funds +
+--   remits to third parties = Money Services Business classification.
+--   FinCEN registration + state money-transmitter licensing in ~48 states
+--   + federal felony exposure under 18 USC § 1960. Stripe Connect shifts
+--   the regulated party to Stripe.
+--
+-- This migration is the minimum schema surface needed to support Connect
+-- (OAuth returns an account_id, we store only that). All status fields —
+-- charges_enabled, payouts_enabled, requirements, disabled_reason,
+-- default_currency — are fetched live from Stripe API at request time.
+-- Zero caching, zero drift, zero secondary source of truth.
+--
+-- Governance references:
+--   §1  Config tier (collective-level setting)
+--   §2  Q6 — setting on existing config table → new column
+--   §4  Stripe's platform data is derived/live, not cached
+--   §8  additive, backward-compatible, rollback included
+--
+-- Linear: NOC-39
+
+BEGIN;
+
+ALTER TABLE public.collectives
+  ADD COLUMN stripe_account_id TEXT;
+
+COMMENT ON COLUMN public.collectives.stripe_account_id IS
+  'Stripe Connect account ID (acct_xxx). OAuth-populated on onboarding. All other state (charges_enabled, payouts_enabled, requirements, etc.) is fetched live from Stripe API at request time — never cached. See NOC-39.';
+
+-- Partial index — only collectives with Connect active need lookup
+CREATE INDEX idx_collectives_stripe_account_id
+  ON public.collectives(stripe_account_id)
+  WHERE stripe_account_id IS NOT NULL;
+
+COMMIT;

--- a/supabase/rollbacks/_rollback_20260422000002_add_collectives_stripe_account_id.sql
+++ b/supabase/rollbacks/_rollback_20260422000002_add_collectives_stripe_account_id.sql
@@ -1,0 +1,11 @@
+-- Rollback for 20260422000002_add_collectives_stripe_account_id.sql
+-- Linear: NOC-39
+
+BEGIN;
+
+DROP INDEX IF EXISTS idx_collectives_stripe_account_id;
+
+ALTER TABLE public.collectives
+  DROP COLUMN IF EXISTS stripe_account_id;
+
+COMMIT;


### PR DESCRIPTION
Closes [NOC-39](https://linear.app/nocturn/issue/NOC-39/stripe-connect-at-launch-msb-regulatory-mitigation-schema-reference)

## Context — pushing back on NOC-27's \"Connect can wait\" framing

Your NOC-27 rejection was right on the implementation pattern (\"store one reference key only, fetch everything else live\"). But the broader claim that Connect isn't launch-blocking deserves a second look.

**The regulatory risk of staying manual:**

Our current flow — Nocturn collects ticket revenue into the platform Stripe account, holds it, then manually transfers to collectives — is the textbook definition of a **Money Services Business / money transmitter**:

- **Federal:** FinCEN registration under 31 CFR § 1022.380 (BSA/AML program, SAR filings, ongoing compliance)
- **State:** Money transmitter licensing in ~48 US states. Surety bonds ($25K–$1M+ each), net-worth minimums, background checks. Full 50-state coverage: $1M–$5M upfront + ongoing
- **Criminal:** Operating as unlicensed money transmitter is a federal felony under 18 USC § 1960

**Connect dissolves this** because funds flow buyer → collective's Stripe account directly, with our platform fee split off automatically. Stripe is the regulated party. Nocturn is a platform, not a transmitter. Same pattern as Posh, Partiful Paid, Eventbrite, Lyft, DoorDash.

**Timing:** No real money = no classification. But the first real ticket sale to a real buyer triggers it, and every subsequent payout is another violation. Given first-5-collectives in May/June, we need Connect live in 4–6 weeks max.

## What this migration does

Just the schema minimum, zero caching, per your NOC-27 rules:

```sql
ALTER TABLE collectives ADD COLUMN stripe_account_id TEXT;
CREATE INDEX idx_collectives_stripe_account_id
  ON collectives(stripe_account_id)
  WHERE stripe_account_id IS NOT NULL;
```

That's it. One TEXT column, one partial index, zero status fields.

## What the follow-up code ticket does

NOC-40-followup (I'll file once this is in): refactor `src/app/actions/stripe-connect.ts` so every status read (charges_enabled, payouts_enabled, requirements, disabled_reason) calls `stripe.accounts.retrieve(account_id)` live instead of reading cached columns. Matches your §4 rule exactly.

## Governance compliance

- **§ 1** — Config tier (collective-level setting)
- **§ 2 Q6** — setting on existing config table → new column
- **§ 4** — Stripe platform data stays derived/live, not cached
- **§ 8** — additive, backward-compatible, rollback included

## Files

- [\`supabase/migrations/20260422000002_add_collectives_stripe_account_id.sql\`](../blob/shawn/noc-39-stripe-connect-reference-column/supabase/migrations/20260422000002_add_collectives_stripe_account_id.sql)
- [\`supabase/rollbacks/_rollback_20260422000002_add_collectives_stripe_account_id.sql\`](../blob/shawn/noc-39-stripe-connect-reference-column/supabase/rollbacks/_rollback_20260422000002_add_collectives_stripe_account_id.sql)

## If you still think Connect can wait past first paid ticket

Then we need legal review before any real ticket sale. The \"Connect is manual for now\" position is defensible for the demo period but not past the first paid transaction. Push back here and Shawn + I will loop in counsel.

\ud83e\udd16 Generated with [Claude Code](https://claude.com/claude-code)