### PR TITLE
schema(NOC-33): restore events.bar_minimum column

### DIFF
--- a/supabase/migrations/20260422000003_restore_events_bar_minimum.sql
+++ b/supabase/migrations/20260422000003_restore_events_bar_minimum.sql
@@ -1,0 +1,22 @@
+-- Restore events.bar_minimum column.
+--
+-- Per Andrew's NOC-24 review: "bar_minimum is a venue contract term.
+-- It's configuration, a planning input you set when you book the venue.
+-- It belongs on the event, same as capacity."
+--
+-- Governance:
+--   §1  Config tier
+--   §2  Q6 — setting on existing config table → new column
+--   §8  additive, backward-compatible, rollback included
+--
+-- Linear: NOC-33
+
+BEGIN;
+
+ALTER TABLE public.events
+  ADD COLUMN bar_minimum NUMERIC(10,2);
+
+COMMENT ON COLUMN public.events.bar_minimum IS
+  'Venue contract minimum bar revenue. If actual bar_share total falls short, shortfall is a venue penalty computed at settlement. Never store the shortfall itself (§4).';
+
+COMMIT;

--- a/supabase/rollbacks/_rollback_20260422000003_restore_events_bar_minimum.sql
+++ b/supabase/rollbacks/_rollback_20260422000003_restore_events_bar_minimum.sql
@@ -1,0 +1,9 @@
+-- Rollback for 20260422000003_restore_events_bar_minimum.sql
+-- Linear: NOC-33
+
+BEGIN;
+
+ALTER TABLE public.events
+  DROP COLUMN IF EXISTS bar_minimum;
+
+COMMIT;


### PR DESCRIPTION
Closes [NOC-33](https://linear.app/nocturn/issue/NOC-33/restore-eventsbar-minimum-column)

Single-column restore per your NOC-24 review — *\"bar_minimum is a venue contract term. It's configuration, a planning input you set when you book the venue. It belongs on the event, same as capacity.\"*

## Migration

```sql
ALTER TABLE public.events ADD COLUMN bar_minimum NUMERIC(10,2);
```

One line. Rollback is one line. Applies independently of NOC-34 and NOC-35.

## Governance

§ 1 Config tier · § 2 Q6 · § 8 additive + rollback included

## Why split from NOC-34

Per your underlying principle in the NOC-24 review: *\"they're not the same thing and they don't belong in the same place.\"* Two 1-line ADD COLUMN migrations (this + NOC-35) shouldn't be gated behind full-table review for revenue_lines. Each applies in 30 seconds.

## Files

- [\`supabase/migrations/20260422000003_restore_events_bar_minimum.sql\`](../blob/shawn/noc-33-restore-events-bar-minimum/supabase/migrations/20260422000003_restore_events_bar_minimum.sql)
- [\`supabase/rollbacks/_rollback_20260422000003_restore_events_bar_minimum.sql\`](../blob/shawn/noc-33-restore-events-bar-minimum/supabase/rollbacks/_rollback_20260422000003_restore_events_bar_minimum.sql)

\ud83e\udd16 Generated with [Claude Code](https://claude.com/claude-code)