### PR TITLE
feat(tasks): click-to-edit task titles with auto-save

### DIFF
--- a/src/app/(dashboard)/dashboard/events/[eventId]/tasks/page.tsx
+++ b/src/app/(dashboard)/dashboard/events/[eventId]/tasks/page.tsx
@@ -304,6 +304,16 @@ function EventTasksPageInner() {
     );
   }
 
+  async function handleUpdateTitle(taskId: string, title: string) {
+    const trimmed = title.trim();
+    if (!trimmed) return; // Empty-title guard; card reverts in-component.
+    // Optimistic update first so the card doesn't flicker back to the old title.
+    setTasks((prev) =>
+      prev.map((t) => ((t.id as string) === taskId ? { ...t, title: trimmed } : t))
+    );
+    await updateTaskDetails(taskId, { title: trimmed });
+  }
+
   async function handleAddSuggestion(suggestion: Suggestion, idx: number) {
     setAddingSuggestionIdx(idx);
     // NOC-32: category + priority columns dropped in PR #93. Suggestion
@@ -752,6 +762,7 @@ function EventTasksPageInner() {
                     onAssign={handleAssign}
                     onSetDue={handleSetDue}
                     onUpdateNote={handleUpdateNote}
+                    onUpdateTitle={handleUpdateTitle}
                     hideDone={hideDone}
                   />
                 );
@@ -822,6 +833,7 @@ function EventTasksPageInner() {
                   onAssign={handleAssign}
                   onSetDue={handleSetDue}
                   onUpdateNote={handleUpdateNote}
+                  onUpdateTitle={handleUpdateTitle}
                 />
               ))}
             </div>
@@ -916,6 +928,7 @@ function CategoryGroup({
   onAssign,
   onSetDue,
   onUpdateNote,
+  onUpdateTitle,
   hideDone,
 }: {
   config: { color: string; label: string; emoji: string };
@@ -926,6 +939,7 @@ function CategoryGroup({
   onAssign: (taskId: string, userId: string | null) => void;
   onSetDue: (taskId: string, dueDate: string | null) => void;
   onUpdateNote: (taskId: string, note: string) => void;
+  onUpdateTitle: (taskId: string, title: string) => void;
   hideDone: boolean;
 }) {
   const [collapsed, setCollapsed] = useState(false);
@@ -963,6 +977,7 @@ function CategoryGroup({
               onAssign={onAssign}
               onSetDue={onSetDue}
               onUpdateNote={onUpdateNote}
+              onUpdateTitle={onUpdateTitle}
             />
           ))}
         </div>
@@ -980,6 +995,7 @@ function TaskCard({
   onAssign,
   onSetDue,
   onUpdateNote,
+  onUpdateTitle,
 }: {
   task: Task;
   members: Member[];
@@ -987,11 +1003,15 @@ function TaskCard({
   onAssign: (taskId: string, userId: string | null) => void;
   onSetDue: (taskId: string, dueDate: string | null) => void;
   onUpdateNote: (taskId: string, note: string) => void;
+  onUpdateTitle: (taskId: string, title: string) => void;
 }) {
   const [showActions, setShowActions] = useState(false);
   const [editingNote, setEditingNote] = useState(false);
   const [noteValue, setNoteValue] = useState(typeof task.description === "string" ? task.description : "");
   const noteRef = useRef<HTMLTextAreaElement>(null);
+  const [editingTitle, setEditingTitle] = useState(false);
+  const [titleDraft, setTitleDraft] = useState(String(task.title));
+  const titleInputRef = useRef<HTMLInputElement>(null);
   const isDone = task.status === "done";
   const nextStatus = task.status === "todo" ? "in_progress" : task.status === "in_progress" ? "done" : "todo";
   const assignee = task.assigned_user as unknown as { full_name: string; email: string } | null;
@@ -1017,9 +1037,34 @@ function TaskCard({
     if (editingNote && noteRef.current) noteRef.current.focus();
   }, [editingNote]);
 
+  useEffect(() => {
+    if (editingTitle && titleInputRef.current) {
+      titleInputRef.current.focus();
+      titleInputRef.current.select();
+    }
+  }, [editingTitle]);
+
   function saveNote() {
     onUpdateNote(task.id as string, noteValue.trim());
     setEditingNote(false);
+  }
+
+  function saveTitle() {
+    const next = titleDraft.trim();
+    const current = String(task.title);
+    if (!next || next === current) {
+      // Empty reverts, unchanged skips — in either case just exit edit mode.
+      setTitleDraft(current);
+      setEditingTitle(false);
+      return;
+    }
+    onUpdateTitle(task.id as string, next);
+    setEditingTitle(false);
+  }
+
+  function cancelTitle() {
+    setTitleDraft(String(task.title));
+    setEditingTitle(false);
   }
 
   return (
@@ -1044,16 +1089,38 @@ function TaskCard({
             </span>
           )}
         </div>
-        <button
-          type="button"
-          className="flex-1 min-w-0 text-left bg-transparent border-0 p-0 cursor-pointer"
-          onClick={() => setShowActions(!showActions)}
-          aria-expanded={showActions}
-        >
-          <span className={`block text-sm font-medium ${isDone ? "line-through text-muted-foreground" : priorityColors[task.priority as string] ?? ""}`}>
-            {String(task.title)}
-          </span>
-          <span className="flex items-center gap-2 mt-1 flex-wrap">
+        <div className="flex-1 min-w-0">
+          {editingTitle ? (
+            <input
+              ref={titleInputRef}
+              type="text"
+              value={titleDraft}
+              onChange={(e) => setTitleDraft(e.target.value)}
+              onBlur={saveTitle}
+              onKeyDown={(e) => {
+                if (e.key === "Enter") { e.preventDefault(); saveTitle(); }
+                if (e.key === "Escape") { e.preventDefault(); cancelTitle(); }
+              }}
+              maxLength={200}
+              aria-label="Edit task title"
+              className={`block w-full text-sm font-medium bg-zinc-900 border border-nocturn/50 rounded px-2 py-1 outline-none text-foreground ${isDone ? "line-through text-muted-foreground" : priorityColors[task.priority as string] ?? ""}`}
+            />
+          ) : (
+            <button
+              type="button"
+              onClick={() => setEditingTitle(true)}
+              className={`block w-full text-left text-sm font-medium bg-transparent border-0 p-0 cursor-text hover:text-foreground transition-colors ${isDone ? "line-through text-muted-foreground" : priorityColors[task.priority as string] ?? ""}`}
+              aria-label="Click to edit title"
+            >
+              {String(task.title)}
+            </button>
+          )}
+          <button
+            type="button"
+            className="w-full text-left bg-transparent border-0 p-0 cursor-pointer flex items-center gap-2 mt-1 flex-wrap min-h-[20px]"
+            onClick={() => setShowActions(!showActions)}
+            aria-expanded={showActions}
+          >
             {dueLabel && (
               <span className={`text-[11px] font-medium ${overdue ? "text-red-400" : "text-muted-foreground"}`}>
                 {overdue ? "🔴 " : ""}{dueLabel}
@@ -1069,8 +1136,9 @@ function TaskCard({
                 <StickyNote className="h-2.5 w-2.5 inline" /> {String(task.description)}
               </span>
             )}
-          </span>
-        </button>
+            <ChevronDown className={`h-3 w-3 text-muted-foreground/60 ml-auto transition-transform ${showActions ? "rotate-180" : ""}`} />
+          </button>
+        </div>
       </div>
 
       {/* Inline actions — assign + due date + note */}
@@ -1148,6 +1216,7 @@ function ContentTaskCard({
   onAssign,
   onSetDue,
   onUpdateNote,
+  onUpdateTitle,
 }: {
   task: Task;
   members: Member[];
@@ -1155,6 +1224,7 @@ function ContentTaskCard({
   onAssign: (taskId: string, userId: string | null) => void;
   onSetDue: (taskId: string, dueDate: string | null) => void;
   onUpdateNote: (taskId: string, note: string) => void;
+  onUpdateTitle: (taskId: string, title: string) => void;
 }) {
   const [expanded, setExpanded] = useState(false);
   const [copied, setCopied] = useState(false);
@@ -1162,6 +1232,9 @@ function ContentTaskCard({
   const [editingNote, setEditingNote] = useState(false);
   const [noteValue, setNoteValue] = useState(typeof task.description === "string" ? task.description : "");
   const noteRef = useRef<HTMLTextAreaElement>(null);
+  const [editingTitle, setEditingTitle] = useState(false);
+  const [titleDraft, setTitleDraft] = useState(String(task.title));
+  const titleInputRef = useRef<HTMLInputElement>(null);
 
   const meta = (task.metadata as Record<string, unknown>) ?? {};
   const platform = (meta.platform as string) ?? "";
@@ -1192,9 +1265,33 @@ function ContentTaskCard({
     if (editingNote && noteRef.current) noteRef.current.focus();
   }, [editingNote]);
 
+  useEffect(() => {
+    if (editingTitle && titleInputRef.current) {
+      titleInputRef.current.focus();
+      titleInputRef.current.select();
+    }
+  }, [editingTitle]);
+
   function saveNote() {
     onUpdateNote(task.id as string, noteValue.trim());
     setEditingNote(false);
+  }
+
+  function saveTitle() {
+    const next = titleDraft.trim();
+    const current = String(task.title);
+    if (!next || next === current) {
+      setTitleDraft(current);
+      setEditingTitle(false);
+      return;
+    }
+    onUpdateTitle(task.id as string, next);
+    setEditingTitle(false);
+  }
+
+  function cancelTitle() {
+    setTitleDraft(String(task.title));
+    setEditingTitle(false);
   }
 
   return (
@@ -1202,16 +1299,38 @@ function ContentTaskCard({
       {/* Top row */}
       <div className="flex items-start gap-3">
         <span className="text-lg shrink-0 mt-0.5">{emoji}</span>
-        <button
-          type="button"
-          className="flex-1 min-w-0 text-left bg-transparent border-0 p-0 cursor-pointer"
-          onClick={() => setShowActions(!showActions)}
-          aria-expanded={showActions}
-        >
-          <span className={`block text-sm font-medium ${isDone ? "line-through text-muted-foreground" : ""}`}>
-            {String(task.title)}
-          </span>
-          <span className="flex items-center gap-2 mt-1 flex-wrap">
+        <div className="flex-1 min-w-0">
+          {editingTitle ? (
+            <input
+              ref={titleInputRef}
+              type="text"
+              value={titleDraft}
+              onChange={(e) => setTitleDraft(e.target.value)}
+              onBlur={saveTitle}
+              onKeyDown={(e) => {
+                if (e.key === "Enter") { e.preventDefault(); saveTitle(); }
+                if (e.key === "Escape") { e.preventDefault(); cancelTitle(); }
+              }}
+              maxLength={200}
+              aria-label="Edit task title"
+              className={`block w-full text-sm font-medium bg-zinc-900 border border-nocturn/50 rounded px-2 py-1 outline-none text-foreground ${isDone ? "line-through text-muted-foreground" : ""}`}
+            />
+          ) : (
+            <button
+              type="button"
+              onClick={() => setEditingTitle(true)}
+              className={`block w-full text-left text-sm font-medium bg-transparent border-0 p-0 cursor-text hover:text-foreground transition-colors ${isDone ? "line-through text-muted-foreground" : ""}`}
+              aria-label="Click to edit title"
+            >
+              {String(task.title)}
+            </button>
+          )}
+          <button
+            type="button"
+            className="w-full text-left bg-transparent border-0 p-0 cursor-pointer flex items-center gap-2 mt-1 flex-wrap min-h-[20px]"
+            onClick={() => setShowActions(!showActions)}
+            aria-expanded={showActions}
+          >
             <span className="rounded-full bg-white/5 border border-white/10 px-1.5 py-0.5 text-[11px] font-medium text-muted-foreground">
               {phase}
             </span>
@@ -1223,8 +1342,9 @@ function ContentTaskCard({
             {assignee && (
               <span className="text-[11px] text-muted-foreground">→ {assignee.full_name ?? assignee.email}</span>
             )}
-          </span>
-        </button>
+            <ChevronDown className={`h-3 w-3 text-muted-foreground/60 ml-auto transition-transform ${showActions ? "rotate-180" : ""}`} />
+          </button>
+        </div>
         <Button
           size="sm"
           variant={isDone ? "default" : "outline"}

--- a/src/app/actions/tasks.ts
+++ b/src/app/actions/tasks.ts
@@ -268,13 +268,22 @@ export async function updateTaskStatus(taskId: string, status: string) {
 // Update task details (assign, due date)
 export async function updateTaskDetails(
   taskId: string,
-  updates: { assignedTo?: string | null; dueAt?: string | null; description?: string | null }
+  updates: { title?: string; assignedTo?: string | null; dueAt?: string | null; description?: string | null }
 ) {
   try {
     const supabase = await createServerClient();
     const { data: { user } } = await supabase.auth.getUser();
     if (!user) return { error: "Not authenticated" };
     if (!taskId?.trim()) return { error: "Task ID is required" };
+
+    // Title validation mirrors createEventTask: trim, non-empty, ≤ 200 chars.
+    // Applied here only when the caller is updating the title.
+    if (updates.title !== undefined) {
+      const trimmed = updates.title.trim();
+      if (!trimmed) return { error: "Task title is required" };
+      if (trimmed.length > 200) return { error: "Task title must be under 200 characters" };
+      updates.title = trimmed;
+    }
 
     const admin = createAdminClient();
     const { data: taskCheck, error: taskCheckError } = await admin
@@ -286,6 +295,7 @@ export async function updateTaskDetails(
     if (!taskCheck || !(await verifyEventAccess(user.id, taskCheck.event_id))) return { error: "Not authorized" };
 
     const dbUpdates: Record<string, unknown> = {};
+    if (updates.title !== undefined) dbUpdates.title = updates.title;
     if (updates.assignedTo !== undefined) dbUpdates.assigned_to = updates.assignedTo;
     if (updates.dueAt !== undefined) dbUpdates.due_at = updates.dueAt;
     if (updates.description !== undefined) dbUpdates.description = updates.description;
@@ -296,6 +306,7 @@ export async function updateTaskDetails(
     if (error) return { error: "Failed to update task" };
 
     const changes: string[] = [];
+    if (updates.title !== undefined) changes.push("renamed");
     if (updates.assignedTo !== undefined) changes.push(updates.assignedTo ? "reassigned" : "unassigned");
     if (updates.dueAt !== undefined) changes.push(`due date ${updates.dueAt ? "set" : "cleared"}`);
     if (updates.description !== undefined) changes.push("note updated");


### PR DESCRIPTION
## Summary

Task titles in Event Playbook were read-only — operators had to delete + recreate a task just to rename it. Click-to-edit now matches the auto-save pattern already used for assignee and due date.

## What changed

**Server** ([src/app/actions/tasks.ts](../blob/fix/task-title-inline-edit/src/app/actions/tasks.ts))
- `updateTaskDetails` accepts an optional `title` update
- Mirrors `createEventTask` validation: trim, non-empty, ≤ 200 chars
- Activity log gets a \`renamed\` entry

**Client** ([tasks/page.tsx](../blob/fix/task-title-inline-edit/src/app/\(dashboard\)/dashboard/events/\[eventId\]/tasks/page.tsx))
- `handleUpdateTitle` with optimistic state update (same shape as `handleUpdateNote`)
- **TaskCard** + **ContentTaskCard**: click title → input, **blur or Enter** saves, **Esc** reverts, empty reverts
- The old "click title to toggle actions" gesture moved to the subtitle row. A `ChevronDown` is always visible at the right edge of the subtitle so it's still clickable when a task has no due/assignee/note pills

## Scope

Non-schema. No migration. Two files touched.

## Verification

- [x] `npx tsc --noEmit` clean
- [x] `npx vitest run` → 88/88 pass
- [x] `npm run build` passes (57/57 pages)
- [ ] Andrew to manually test rename flow on QA preview after merge

## Test plan
- [ ] On `/dashboard/events/:id/tasks`: click a task title → input appears focused and text selected
- [ ] Type a new title + Tab/click-outside → saves, chip updates, activity log shows "renamed"
- [ ] Type + press Enter → same save
- [ ] Type + press Esc → reverts to original title
- [ ] Clear the title to empty + blur → reverts (no empty-title save)
- [ ] Subtitle row / chevron still toggles the assign + due date + note panel
- [ ] Works for both "General" task list and any ContentTaskCard codepath (currently dead-gated, but matches pattern)

🤖 Generated with [Claude Code](https://claude.com/claude-code)