### PR TITLE
fix: mobile/desktop QA sweep — iOS auto-zoom, tap targets, body overflow

### DIFF
--- a/src/app/(auth)/signup/page.tsx
+++ b/src/app/(auth)/signup/page.tsx
@@ -234,7 +234,7 @@ export default function SignupPage() {
                     <div className="flex items-center gap-2 mb-0.5">
                       <p className="font-semibold text-sm text-foreground">{label}</p>
                       {tagline && (
-                        <span className="text-[10px] font-mono font-medium uppercase tracking-wider text-nocturn-glow bg-nocturn/10 border border-nocturn/20 rounded-full px-2 py-0.5">
+                        <span className="text-[11px] font-mono font-medium uppercase tracking-wider text-nocturn-glow bg-nocturn/10 border border-nocturn/20 rounded-full px-2 py-0.5">
                           {tagline}
                         </span>
                       )}

--- a/src/app/(dashboard)/dashboard/events/[eventId]/edit/edit-event-form.tsx
+++ b/src/app/(dashboard)/dashboard/events/[eventId]/edit/edit-event-form.tsx
@@ -467,7 +467,7 @@ export function EditEventForm({ event }: { event: EventData }) {
               id="eventCurrency"
               value={eventCurrency}
               onChange={(e) => setEventCurrency(e.target.value)}
-              className="w-full bg-zinc-900 border border-white/10 rounded-xl px-3 text-sm text-white focus:border-nocturn/50 focus:outline-none min-h-[44px]"
+              className="w-full bg-zinc-900 border border-white/10 rounded-xl px-3 text-base md:text-sm text-white focus:border-nocturn/50 focus:outline-none min-h-[44px]"
             >
               {SUPPORTED_CURRENCIES.map((c) => (
                 <option key={c.code} value={c.code}>{c.label}</option>
@@ -516,7 +516,7 @@ export function EditEventForm({ event }: { event: EventData }) {
                         value={row.currency}
                         onChange={(e) => updateExpense(i, { currency: e.target.value })}
                         aria-label={`${row.label || "Row"} currency`}
-                        className="bg-zinc-900 border border-white/10 rounded-lg px-2 text-sm text-white focus:border-nocturn/50 focus:outline-none min-h-[40px] min-w-[72px]"
+                        className="bg-zinc-900 border border-white/10 rounded-lg px-2 text-base md:text-sm text-white focus:border-nocturn/50 focus:outline-none min-h-[44px] min-w-[72px]"
                       >
                         {SUPPORTED_CURRENCIES.map((c) => (
                           <option key={c.code} value={c.code}>{c.code.toUpperCase()}</option>

--- a/src/app/(dashboard)/dashboard/events/[eventId]/live/page.tsx
+++ b/src/app/(dashboard)/dashboard/events/[eventId]/live/page.tsx
@@ -287,7 +287,7 @@ export default function LiveEventPage() {
         <div className="flex-1 min-w-0">
           <div className="flex items-center gap-2.5 flex-wrap">
             <LiveBadge />
-            <div className="section-label-mono !mb-0 text-[10px]">DOORS OPEN · {formatElapsed(elapsed)}</div>
+            <div className="section-label-mono !mb-0 text-[11px]">DOORS OPEN · {formatElapsed(elapsed)}</div>
           </div>
           <h1 className="text-xl font-bold truncate font-heading mt-1 tracking-[-0.02em]">
             {event.title}
@@ -324,7 +324,7 @@ export default function LiveEventPage() {
       {/* Secondary stats — Door revenue row */}
       <div className="grid grid-cols-2 gap-px bg-white/[0.06] border border-white/[0.06] rounded-xl overflow-hidden">
         <div className="bg-background p-5">
-          <div className="section-label-mono !mb-2 !text-[10px]">THE DOOR</div>
+          <div className="section-label-mono !mb-2 !text-[11px]">THE DOOR</div>
           <div className="flex items-baseline gap-1.5">
             <span className="font-heading text-3xl font-semibold text-white tabular-nums">
               ${revenue.toLocaleString()}
@@ -335,7 +335,7 @@ export default function LiveEventPage() {
           </p>
         </div>
         <div className="bg-background p-5">
-          <div className="section-label-mono !mb-2 !text-[10px]">WALK-UPS</div>
+          <div className="section-label-mono !mb-2 !text-[11px]">WALK-UPS</div>
           <div className="flex items-baseline gap-1.5">
             <span className="font-heading text-3xl font-semibold text-white tabular-nums">
               {recentCheckIns.filter(c => c.tier_name === "Walk-up" || c.tier_name === "Door").length}
@@ -359,7 +359,7 @@ export default function LiveEventPage() {
         return (
           <div className={`rounded-xl border ${atRisk ? "border-red-500/25 bg-red-500/[0.04]" : "border-emerald-500/25 bg-emerald-500/[0.04]"} p-5`}>
             <div className="flex items-center justify-between mb-3">
-              <div className="section-label-mono !mb-0 !text-[10px]">BAR MINIMUM</div>
+              <div className="section-label-mono !mb-0 !text-[11px]">BAR MINIMUM</div>
               <div className="flex items-center gap-2">
                 <span className={`h-2 w-2 rounded-full ${atRisk ? "bg-red-400" : "bg-emerald-400"}`} />
                 <span className={`text-[11px] font-mono uppercase tracking-widest ${atRisk ? "text-red-400" : "text-emerald-400"}`}>
@@ -390,7 +390,7 @@ export default function LiveEventPage() {
 
       {/* Quick Actions */}
       <div>
-        <div className="section-label-mono mb-3 !text-[10px]">QUICK ACTIONS</div>
+        <div className="section-label-mono mb-3 !text-[11px]">QUICK ACTIONS</div>
         <div className="grid grid-cols-2 gap-px bg-white/[0.06] border border-white/[0.06] rounded-xl overflow-hidden">
           <Link href={`/dashboard/events/${eventId}/check-in`} className="group">
             <button className="w-full flex flex-col items-center justify-center gap-2 bg-background p-5 min-h-[88px] hover:bg-nocturn/[0.04] active:scale-[0.98] transition-all">
@@ -442,7 +442,7 @@ export default function LiveEventPage() {
       {/* Door Activity Feed */}
       <div className="rounded-xl border border-white/[0.06] bg-background overflow-hidden">
         <div className="px-5 py-3 border-b border-white/[0.06]">
-          <div className="section-label-mono !mb-0 !text-[10px]">DOOR ACTIVITY</div>
+          <div className="section-label-mono !mb-0 !text-[11px]">DOOR ACTIVITY</div>
         </div>
         {recentCheckIns.length === 0 ? (
           <div className="px-5 py-10 text-center">

--- a/src/app/(dashboard)/dashboard/events/[eventId]/tasks/page.tsx
+++ b/src/app/(dashboard)/dashboard/events/[eventId]/tasks/page.tsx
@@ -1103,7 +1103,7 @@ function TaskCard({
               }}
               maxLength={200}
               aria-label="Edit task title"
-              className={`block w-full text-sm font-medium bg-zinc-900 border border-nocturn/50 rounded px-2 py-1 outline-none text-foreground ${isDone ? "line-through text-muted-foreground" : priorityColors[task.priority as string] ?? ""}`}
+              className={`block w-full text-base md:text-sm font-medium bg-zinc-900 border border-nocturn/50 rounded px-2 py-1 outline-none text-foreground ${isDone ? "line-through text-muted-foreground" : priorityColors[task.priority as string] ?? ""}`}
             />
           ) : (
             <button
@@ -1313,7 +1313,7 @@ function ContentTaskCard({
               }}
               maxLength={200}
               aria-label="Edit task title"
-              className={`block w-full text-sm font-medium bg-zinc-900 border border-nocturn/50 rounded px-2 py-1 outline-none text-foreground ${isDone ? "line-through text-muted-foreground" : ""}`}
+              className={`block w-full text-base md:text-sm font-medium bg-zinc-900 border border-nocturn/50 rounded px-2 py-1 outline-none text-foreground ${isDone ? "line-through text-muted-foreground" : ""}`}
             />
           ) : (
             <button

--- a/src/app/(dashboard)/dashboard/events/new/page.tsx
+++ b/src/app/(dashboard)/dashboard/events/new/page.tsx
@@ -1479,7 +1479,7 @@ function MoneyRow({ label, placeholder, value, onChange, eventCurrency, Icon, on
           value={value.currency}
           onChange={(e) => onChange({ ...value, currency: e.target.value })}
           aria-label={`${label} currency`}
-          className="bg-zinc-900 border border-white/10 rounded-lg px-2 text-sm text-white focus:border-nocturn/50 focus:outline-none min-h-[40px] min-w-[72px]"
+          className="bg-zinc-900 border border-white/10 rounded-lg px-2 text-base md:text-sm text-white focus:border-nocturn/50 focus:outline-none min-h-[44px] min-w-[72px]"
         >
           {SUPPORTED_CURRENCIES.map(c => (
             <option key={c.code} value={c.code}>{c.code.toUpperCase()}</option>
@@ -1654,7 +1654,7 @@ function BudgetStep({
             value={ec}
             onChange={(e) => setDraft(prev => ({ ...prev, eventCurrency: e.target.value }))}
             aria-label="Event currency"
-            className="w-full bg-zinc-900 border border-white/10 rounded-xl px-3 text-sm text-white focus:border-nocturn/50 focus:outline-none min-h-[44px]"
+            className="w-full bg-zinc-900 border border-white/10 rounded-xl px-3 text-base md:text-sm text-white focus:border-nocturn/50 focus:outline-none min-h-[44px]"
           >
             {SUPPORTED_CURRENCIES.map(c => (
               <option key={c.code} value={c.code}>{c.label}</option>
@@ -1852,7 +1852,7 @@ function BudgetStep({
                       value={p.currency}
                       onChange={(e) => updateProdItem(i, { currency: e.target.value })}
                       aria-label={`${p.label} currency`}
-                      className="bg-zinc-900 border border-white/10 rounded-lg px-2 text-sm text-white focus:border-nocturn/50 focus:outline-none min-h-[40px] min-w-[72px]"
+                      className="bg-zinc-900 border border-white/10 rounded-lg px-2 text-base md:text-sm text-white focus:border-nocturn/50 focus:outline-none min-h-[44px] min-w-[72px]"
                     >
                       {SUPPORTED_CURRENCIES.map(c => (
                         <option key={c.code} value={c.code}>{c.code.toUpperCase()}</option>

--- a/src/app/(dashboard)/dashboard/settings/page.tsx
+++ b/src/app/(dashboard)/dashboard/settings/page.tsx
@@ -492,7 +492,7 @@ function CurrencyCard() {
             value={currency}
             onChange={(e) => setCurrency(e.target.value)}
             disabled={loading || saving}
-            className="w-full bg-zinc-900 border border-white/10 rounded-xl px-3 text-sm text-white focus:border-nocturn/50 focus:outline-none min-h-[44px] disabled:opacity-50"
+            className="w-full bg-zinc-900 border border-white/10 rounded-xl px-3 text-base md:text-sm text-white focus:border-nocturn/50 focus:outline-none min-h-[44px] disabled:opacity-50"
           >
             {SUPPORTED_CURRENCIES.map(c => (
               <option key={c.code} value={c.code}>{c.label}</option>

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -140,6 +140,8 @@
     overscroll-behavior: none;
     /* Prevent text size adjust on orientation change */
     -webkit-text-size-adjust: 100%;
+    /* Kill any accidental horizontal scroll (rogue wide elements, long strings) */
+    overflow-x: hidden;
   }
   h1, h2, h3, h4, h5, h6 {
     font-family: var(--font-heading), "Space Grotesk", ui-sans-serif, sans-serif;


### PR DESCRIPTION
## Summary

Codebase-wide mobile/desktop QA audit. 12 violations found, all CSS/className — no schema, no component API changes.

**Fixes:**
- 8× iOS Safari auto-zoom: native `<select>`/`<input>` with bare `text-sm` → `text-base md:text-sm` (currency pickers in events/new, edit-event-form, settings; task title inline-edit inputs)
- 3× tap targets: currency selects lifted from `min-h-[40px]` → `min-h-[44px]`
- 7× tiny text: `text-[10px]` → `text-[11px]` in event live page mono labels and signup pricing tagline
- 1× horizontal overflow: `body { overflow-x: hidden }` in globals.css to catch any rogue wide element

**Audit also confirmed clean:**
- 0 `window.confirm` / `window.alert` (project uses custom `confirm()` dialog)
- 0 `min-h-screen` / `h-screen` layout violations (only 1 keyframe in CSS)
- 0 `text-[8px]` / `text-[9px]`
- All `fixed bottom-0` / `sticky bottom-0` already use `env(safe-area-inset-bottom)`
- `Button` and `Input` primitives already enforce `min-h-[44px]` and `text-base md:text-sm`
- 606 hover states across 129 files; desktop responsive breakpoints intact

## Test plan
- [ ] Open QA preview in iOS Safari simulator
- [ ] Tap currency select on /dashboard/events/new → no zoom-in
- [ ] Tap currency select on /dashboard/settings → no zoom-in
- [ ] Tap task title to inline-edit on /dashboard/events/[id]/tasks → no zoom-in
- [ ] /dashboard/events/[id]/live mono labels readable at arm's length
- [ ] No horizontal scroll on any page in mobile portrait

🤖 Generated with [Claude Code](https://claude.com/claude-code)